### PR TITLE
Improve Chord Parser in Quick Lyrics

### DIFF
--- a/src/frontend/converters/txt.ts
+++ b/src/frontend/converters/txt.ts
@@ -49,14 +49,10 @@ export function convertText({ name = "", origin = "", category = null, text, noF
     // in "Text edit" spaces can be used to create empty "child" slides
     text = text.replaceAll("\r", "").replaceAll("\n \n", "\n\n")
 
-    // preprocess chord lines before splitting into sections (only if formatting is enabled)
-    const formatText: boolean = noFormatting ? false : get(formatNewShow)
-    let processedText = text
-    if (formatText) {
-        const allLines = text.split("\n")
-        const processedLines = preprocessLines(allLines)
-        processedText = processedLines.join("\n")
-    }
+    // preprocess chord lines before splitting into sections
+    const allLines = text.split("\n")
+    const processedLines = preprocessLines(allLines)
+    const processedText = processedLines.join("\n")
 
     let sections = processedText.split("\n\n").filter(Boolean)
 
@@ -265,7 +261,7 @@ function insertChordsIntoLyrics(chordLine: string, lyricLine: string): string {
         
         chords.push({
             chord: match[0],
-            position,
+            position: position,
         })
     }
 
@@ -394,41 +390,39 @@ function createSlides(labeled: { type: string; text: string }[], noFormatting) {
             const textLength = items.reduce((value, item) => (value += getItemText(item).length), 0)
             if (!textLength) items = []
 
-            // extract chords (chordpro) - only if formatting is enabled
-            if (formatText) {
-                items = items.map((item) => {
-                    item.lines?.forEach((line) => {
-                        const chords: Chords[] = []
-                        let letterIndex = 0
-                        let isChord = false
+            // extract chords (chordpro)
+            items = items.map((item) => {
+                item.lines?.forEach((line) => {
+                    const chords: Chords[] = []
+                    let letterIndex = 0
+                    let isChord = false
 
-                        line?.text?.forEach((text) => {
-                            let newValue = ""
-                            text.value?.split("").forEach((char) => {
-                                if ((char === "[" || char === "]") && !text.value.slice(0, -2).includes(":")) {
-                                    isChord = char === "["
-                                    if (isChord) chords.push({ id: uid(5), pos: letterIndex, key: "" })
-                                    return
-                                }
+                    line?.text?.forEach((text) => {
+                        let newValue = ""
+                        text.value?.split("").forEach((char) => {
+                            if ((char === "[" || char === "]") && !text.value.slice(0, -2).includes(":")) {
+                                isChord = char === "["
+                                if (isChord) chords.push({ id: uid(5), pos: letterIndex, key: "" })
+                                return
+                            }
 
-                                if (isChord) {
-                                    chords[chords.length - 1].key += char
-                                    return
-                                }
+                            if (isChord) {
+                                chords[chords.length - 1].key += char
+                                return
+                            }
 
-                                newValue += char
-                                letterIndex++
-                            })
-
-                            text.value = newValue.replaceAll("\r", "")
+                            newValue += char
+                            letterIndex++
                         })
 
-                        if (chords.length) line.chords = chords
+                        text.value = newValue.replaceAll("\r", "")
                     })
 
-                    return item
+                    if (chords.length) line.chords = chords
                 })
-            }
+
+                return item
+            })
 
             if (slideIndex > 0) {
                 // don't add empty slides as children (but allow e.g. "Break")


### PR DESCRIPTION
Sorry, still new to coding, so I'm not sure if I did the request right. The only edit is to src/frontend/converters/txt.ts

Marking as draft, as I haven't created an issue (more of a continuation of [#1653](https://github.com/ChurchApps/FreeShow/issues/1653#issuecomment-2894321195)). Currently, I can't paste songs from places like [Ultimate Guitar ](https://tabs.ultimate-guitar.com/) or [pnwchords](https://pnwchords.com/) without some sort of issue, such as improper chord placement or blank slides.  

This improved chord parsing and has worked for songs from both Ultimate Guitar and pnwchords.

I haven't tested normal songs or other inputs, as I don't know how else people use Quick Lyrics. Let me know if any changes are needed. 