### PR TITLE
Fix duplicated .local in macOS

### DIFF
--- a/src/frontend/components/main/popups/Connect.svelte
+++ b/src/frontend/components/main/popups/Connect.svelte
@@ -41,7 +41,6 @@
     }
 
     $: port = $ports[id] || defaultPorts[id]
-    console.log('🚀 ~ os:', $os)
     $: hostname = `${$os.name.toLowerCase()}${$os.platform === 'win32' ? '.local' : ''}`
     $: url = `http://${useHostname ? hostname : ip}:${port}`
     $: if (url) generateQR(url)


### PR DESCRIPTION
In version 1.4.9-beta3, I switched `Use hostname instead of IP` toggle.
On macOS, this caused a duplicated `.local` suffix in the hostname (e.g. `hostname.local.local`).
The issue does not occur on Windows.

To fix this, I added an OS platform check and only append `.local` when running on Windows.

<img width="627" height="279" alt="image" src="https://github.com/user-attachments/assets/f2b18e5c-863c-4e3a-9de9-bf7c1466697c" />
