### PR TITLE
Chord sheet option appears immediately when entering PDF export modal

### DIFF
--- a/src/frontend/components/main/popups/export/Export.svelte
+++ b/src/frontend/components/main/popups/export/Export.svelte
@@ -155,7 +155,7 @@
 
     {#if exportFormat === "pdf"}
         <HRule />
-        <PdfExport bind:pdfOptions {previewShow} />
+        <PdfExport bind:pdfOptions {previewShow} {loading} />
     {:else if exportFormat === "project"}
         <MaterialToggleSwitch label="export.include_media" style="margin-top: 20px;" checked={$special.projectIncludeMedia ?? true} defaultValue={true} on:change={(e) => setSpecial(e, "projectIncludeMedia")} />
     {/if}

--- a/src/frontend/components/main/popups/export/PdfExport.svelte
+++ b/src/frontend/components/main/popups/export/PdfExport.svelte
@@ -10,8 +10,15 @@
 
     export let pdfOptions: any
     export let previewShow: Show | null
+    export let loading = false
+
+    // Reset type to default if current type is not available in options
+    $: if (pdfOptions.type && pdfTypeOptions.length && !pdfTypeOptions.find(opt => opt.value === pdfOptions.type)) {
+        pdfOptions.type = "default"
+    }
 
     let paper: any = null
+    let pdfTypeOptions: any[] = []
 
     if (!Object.keys(pdfOptions).length) {
         pdfOptions = {
@@ -43,12 +50,24 @@
         }
     }
 
-    const pdfTypeOptions = [
-        { value: "default", label: translateText("example.default") },
-        { value: "text", label: translateText("export.text") },
-        { value: "slides", label: translateText("export.slides") },
-        ...(showHasChords(previewShow) ? [{ value: "chordSheet", label: "Chord Sheet" }] : [])
-    ]
+    // Initialize pdfTypeOptions
+    function updatePdfTypeOptions() {
+        const baseOptions = [
+            { value: "default", label: translateText("example.default") },
+            { value: "text", label: translateText("export.text") },
+            { value: "slides", label: translateText("export.slides") }
+        ]
+
+        // Add chord sheet option if show has chords
+        if (previewShow && showHasChords(previewShow)) {
+            baseOptions.push({ value: "chordSheet", label: "Chord Sheet" })
+        }
+
+        pdfTypeOptions = baseOptions
+    }
+
+    // Update pdfTypeOptions when previewShow changes
+    $: if (previewShow !== undefined) updatePdfTypeOptions()
 
     function showHasChords(show: Show | null): boolean {
         if (!show) return false
@@ -64,7 +83,7 @@
 <!-- min-width: 42vw; -->
 <div style="display: flex;gap: 15px;">
     <div class="options" style="flex: 0 0 300px;">
-        <MaterialDropdown label="clock.type" style="margin-bottom: 10px;" options={pdfTypeOptions} value={pdfOptions.type || "default"} on:change={(e) => (pdfOptions.type = e.detail)} />
+        <MaterialDropdown label="clock.type" style="margin-bottom: 10px;" options={pdfTypeOptions} value={pdfOptions.type || "default"} disabled={loading} on:change={(e) => (pdfOptions.type = e.detail)} />
 
         <!-- <MaterialCheckbox label="export.title" checked={pdfOptions.title} on:change={(e) => updatePdfOptions(e, "title")} /> -->
 


### PR DESCRIPTION
Currently, the chord sheet option only appears after navigating back from the PDF modal to the format selection and then back to PDF again.

Pretty sure this is a bug, so this PR should fix it.
