### PR TITLE
Replaced CSS zoom with transform-based scaling

### DIFF
--- a/src/server/remote/components/show/Zoomed.svelte
+++ b/src/server/remote/components/show/Zoomed.svelte
@@ -8,15 +8,21 @@
     export let checkered: boolean = false
 
     export let ratio: number = 1
-    $: ratio = slideWidth / 1920
+    let baseWidth: number = 1920
+    let baseHeight: number = 1080
+    $: baseWidth = resolution?.width ?? 1920
+    $: baseHeight = resolution?.height ?? 1080
+    let slideHeight: number = 0
+    // Fit to both width and height to avoid overflow on Safari
+    $: ratio = Math.min(slideWidth / baseWidth, slideHeight / baseHeight)
 
     let slideWidth: number = 0
 </script>
 
 <div class:center>
-    <div bind:offsetWidth={slideWidth} class="slide" class:hideOverflow class:checkered style="{$$props.style || ''}background-color: {background};aspect-ratio: {resolution.width}/{resolution.height};">
-        <!-- WIP firefox does not support "zoom": https://stackoverflow.com/questions/4049342/how-can-i-zoom-an-html-element-in-firefox-and-opera (-moz-transform: scale({ratio});) -->
-        <span style="zoom: {ratio};">
+    <div bind:offsetWidth={slideWidth} bind:offsetHeight={slideHeight} class="slide" class:hideOverflow class:checkered style="{$$props.style || ''}background-color: {background};aspect-ratio: {resolution.width}/{resolution.height};">
+        <!-- Use transform scale for cross-browser support (Safari/Firefox do not support CSS zoom) -->
+        <span style="display: inline-block; width: {baseWidth}px; height: {baseHeight}px; transform: scale({isFinite(ratio) && ratio > 0 ? ratio : 1}); transform-origin: top left; will-change: transform;">
             <slot />
         </span>
     </div>

--- a/src/server/remote/components/tablet/TabletMode.svelte
+++ b/src/server/remote/components/tablet/TabletMode.svelte
@@ -482,6 +482,8 @@
     .left,
     .right {
         width: 290px;
+        max-width: 35vw; /* prevent side panels from forcing horizontal scroll on tablets */
+        overflow: hidden;
     }
 
     .left {
@@ -493,6 +495,8 @@
 
     .center {
         flex: 1;
+        min-width: 0; /* allow flexbox to shrink center to available width */
+        overflow: hidden; /* prevent inner content from creating page-wide overflow */
     }
 
     /* Resizers */
@@ -595,6 +599,14 @@
     .outSlides {
         display: flex;
         width: 100%;
+    }
+
+    /* Tablet/iPad specific safeguards */
+    @media (max-width: 1180px) {
+        .left,
+        .right {
+            max-width: 32vw;
+        }
     }
 
     /* fullscreen */

--- a/src/server/stage/components/Zoomed.svelte
+++ b/src/server/stage/components/Zoomed.svelte
@@ -6,16 +6,21 @@
 
     let resolution: any = show && show.settings.resolution ? show.settings.resolution : { width: 1920, height: 1080 } // $screen.resolution
     let slideWidth: number = 0
+    let slideHeight: number = 0
     let ratio: number = 1
-    $: ratio = slideWidth / resolution?.width
+    $: ratio = Math.min(
+        slideWidth / (resolution?.width || 1920),
+        slideHeight / (resolution?.height || 1080)
+    )
 
     // dynamic resolution
     if (dynamicResolution) resolution = { width: window.innerWidth, height: window.innerHeight }
 </script>
 
 <div class="center">
-    <div bind:offsetWidth={slideWidth} class:disableStyle class:relative class="slide" style="{$$props.style || ''}aspect-ratio: {resolution?.width}/{resolution?.height};">
-        <span style="zoom: {ratio};">
+    <div bind:offsetWidth={slideWidth} bind:offsetHeight={slideHeight} class:disableStyle class:relative class="slide" style="{$$props.style || ''}aspect-ratio: {resolution?.width}/{resolution?.height};">
+        <!-- Use transform scale for cross-browser support (Safari/Firefox do not support CSS zoom) -->
+        <span style="display: inline-block; width: {resolution?.width || 1920}px; height: {resolution?.height || 1080}px; transform: scale({isFinite(ratio) && ratio > 0 ? ratio : 1}); transform-origin: top left; will-change: transform;">
             <slot />
         </span>
     </div>


### PR DESCRIPTION
It works, but I'm not sure if it's the ideal way. I couldn't get userAgent working in FreeShow Remote, and I think the problem is best solved from the root.

https://github.com/ChurchApps/FreeShow/issues/2316

Tested on mobile, desktop and iOS