### PR TITLE
Add additional snapcraft plugs

### DIFF
--- a/config/building/snapcraft.yaml
+++ b/config/building/snapcraft.yaml
@@ -40,6 +40,7 @@ parts:
         stage-packages:
             - libasound2t64
             - libnode109
+            - libglu1-mesa
 apps:
     freeshow:
         command: command.sh


### PR DESCRIPTION
I noticed the snap wasn't broadcasting NDI. This should fix that, and add GPU hardware acceleration access.