### PR TITLE
auto-size caching and optimizing

### DIFF
--- a/src/frontend/components/helpers/output.ts
+++ b/src/frontend/components/helpers/output.ts
@@ -780,6 +780,13 @@ export function mergeWithTemplate(slideItems: Item[], templateItems: Item[], add
     // should be reversed, but people have to invert the order of their template items order.
     templateItems = clone(templateItems) // .reverse()
 
+    if (resetAutoSize) {
+        templateItems.forEach((item) => {
+            if (!item) return
+            delete item.autoFontSize
+        })
+    }
+
     const sorted = sortItemsByType(templateItems)
     const sortedTemplateItems = clone(sorted)
 

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -56,16 +56,21 @@
             let customTemplate = getStyleTemplate(outSlide, currentStyle)
             if (!Object.keys(customTemplate).length && outSlide?.id === "temp") customTemplate = $templates[$scriptureSettings.template] || {}
 
-            // wait output style/scripture template auto size
-            if (Object.keys(customTemplate).length ? slideHasAutoSizeItem(customTemplate) : item.auto) outDelay = 500
+            // only keep the legacy autosize delay when nothing has pre-populated a font size yet
+            const templateNeedsAutoSize = Object.keys(customTemplate).length ? slideHasAutoSizeItem(customTemplate) : false
+            const itemNeedsAutoSize = item.auto && !item.autoFontSize
 
-            if (!inDelay) inDelay = outDelay * 0.98
+            if (templateNeedsAutoSize || itemNeedsAutoSize) {
+                outDelay = 500
+                if (!inDelay) inDelay = outDelay * 0.98
+            }
         }
 
         // add some time in case an identical item is "fading" in
         if (!outDelay && itemTransition?.duration === 0 && item.type === "media") outDelay = 250
-        // don't "go to black" in between text
-        else if (!outDelay && transition?.duration === 0) outDelay = 50
+        // the previous fallback kept the old item visible a moment longer to avoid a black flash,
+        // but the autosize precompute path already keeps the new content ready, so we let the
+        // zero-duration case swap immediately to prevent overlapping text.
         // WIP having outDelay on just 1 item will cause all other items to not clear until that is finished!
 
         // SET DELAY

--- a/src/frontend/components/slide/Textbox.svelte
+++ b/src/frontend/components/slide/Textbox.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import { onDestroy, onMount } from "svelte"
+    import { createEventDispatcher, onDestroy, onMount } from "svelte"
     import { OUTPUT } from "../../../types/Channels"
     import type { Styles } from "../../../types/Settings"
     import type { Item, Transition, TemplateStyleOverride, Slide } from "../../../types/Show"
@@ -13,6 +13,7 @@
     import { getStyles } from "../helpers/style"
     import SlideItems from "./SlideItems.svelte"
     import TextboxLines from "./TextboxLines.svelte"
+    import { readAutoSizeCache, writeAutoSizeCache } from "./autosizeCache"
 
     export let item: Item
     export let itemIndex = -1
@@ -56,6 +57,12 @@
     export let centerPreview = false
     export let revealed = -1
     export let styleIdOverride = ""
+    // expose an optional key so parents can track autosize readiness per item
+    export let autoSizeKey = ""
+
+    // reuse autosize work across components by caching measurements alongside a signature
+    // surface measurement completion for parents that want to precompute autosize
+    const dispatch = createEventDispatcher<{ autosizeReady: { key: string; fontSize: number } }>()
 
     $: lines = clone(item?.lines)
     $: if (linesStart !== null && linesEnd !== null && lines?.length) {
@@ -74,6 +81,12 @@
     // timer updater
     let loaded = false
     let dateInterval: NodeJS.Timeout | null = null
+    // track readiness to avoid duplicate events for the same render cycle
+    let autoSizeReady = false
+    // hold onto whether the visible output should stay hidden until autosize finishes
+    let hideUntilAutosized = false
+    // remember which item signature we already reset local font size for
+    let lastRenderedSignature = ""
     onMount(() => {
         setTimeout(() => (loaded = true), 100)
     })
@@ -174,6 +187,12 @@
 
     let previousItem = "{}"
     $: newItem = JSON.stringify(item)
+    $: if (newItem !== previousItem) autoSizeReady = false
+    $: if (newItem !== lastRenderedSignature) {
+        fontSize = item?.autoFontSize || 0
+        lastRenderedSignature = newItem
+        hideUntilAutosized = shouldHideUntilAutoSizeCompletes()
+    }
     $: if (itemElem && loaded && (stageAutoSize || newItem !== previousItem || chordLines || stageItem)) calculateAutosize()
     $: if ($variables) setTimeout(calculateAutosize)
 
@@ -188,6 +207,25 @@
     // $: fontSizeValue = stageAutoSize || item.auto || outputTemplateAutoSize ? fontSize : fontSize
 
     let customTypeRatio = 1
+    function deriveCustomTypeRatio() {
+        if (isStage) {
+            let text = stageItem?.lines?.[0]?.text || []
+            if (!Array.isArray(text) || !text.length) return 1
+            const verseItemText = text.filter((a) => a.customType?.includes("disableTemplate")) || []
+            if (!verseItemText.length) return 1
+            const verseItemSize = Number(getStyles(verseItemText[0]?.style, true)?.["font-size"] || "") || 0
+            const stageFontSize = Number(getStyles(stageItem?.style, true)?.["font-size"] || "") || 100
+            return stageFontSize ? verseItemSize / stageFontSize || 1 : 1
+        }
+
+        let text = item?.lines?.[0]?.text || []
+        if (!Array.isArray(text) || !text.length) return 1
+        const verseItemText = text.filter((a) => a.customType?.includes("disableTemplate")) || []
+        if (!verseItemText.length) return 1
+        const verseItemSize = Number(getStyles(verseItemText[0]?.style, true)?.["font-size"] || "") || 0
+        return verseItemSize ? verseItemSize / 100 || 1 : 1
+    }
+    $: customTypeRatio = deriveCustomTypeRatio()
 
     let loopStop: NodeJS.Timeout | null = null
     let newCall = false
@@ -244,6 +282,21 @@
         let elem = itemElem
         if (!elem) return
 
+        // short-circuit expensive DOM work when we already measured identical content
+        const cacheKey = buildAutoSizeCacheKey()
+        const cacheSignature = buildAutoSizeSignature()
+        const cachedResult = cacheKey ? readAutoSizeCache(cacheKey) : undefined
+        if (cachedResult && cachedResult.signature === cacheSignature) {
+            fontSize = cachedResult.fontSize
+            if (item.type === "slide_tracker") {
+                markAutoSizeReady()
+                return
+            }
+            if (fontSize !== item.autoFontSize) setItemAutoFontSize(fontSize)
+            markAutoSizeReady()
+            return
+        }
+
         let textQuery = ""
         if (isTextItem) {
             elem = elem.querySelector(".align") as HTMLElement
@@ -263,8 +316,64 @@
         // smaller in general if bullet list, because they are not accounted for
         if (item?.list?.enabled) fontSize *= 0.9
 
-        if (item.type === "slide_tracker") return
+        if (item.type === "slide_tracker") {
+            if (cacheKey) writeAutoSizeCache(cacheKey, { signature: cacheSignature, fontSize })
+            markAutoSizeReady()
+            return
+        }
         if (fontSize !== item.autoFontSize) setItemAutoFontSize(fontSize)
+        if (cacheKey) writeAutoSizeCache(cacheKey, { signature: cacheSignature, fontSize })
+        markAutoSizeReady()
+    }
+
+    // generate a stable key scoped to the item and current output context
+    function buildAutoSizeCacheKey() {
+        if (!autoSizeKey && !ref?.id) return ""
+        const base = autoSizeKey || `${ref?.id || ""}-${item?.id || itemIndex}`
+        const target = isStage ? "stage" : ref?.type || "show"
+        return `${target}:${base}`
+    }
+
+    // capture the bits of state that influence autosize outcomes for cache invalidation
+    function buildAutoSizeSignature() {
+        return JSON.stringify({
+            lines: item?.lines,
+            style: item?.style,
+            textFit: item?.textFit,
+            list: item?.list,
+            chords,
+            stageAutoSize,
+            stageItem,
+            fontSizeOverride: customFontSize,
+            ratio,
+            outputStyle,
+            styleIdOverride,
+            mirror,
+            preview,
+            smallFontSize,
+            maxLines,
+            maxLinesInvert,
+            centerPreview
+        })
+    }
+
+    // notify listeners that autosize finished (and stash readiness for this render)
+    function markAutoSizeReady() {
+        if (autoSizeReady) return
+        autoSizeReady = true
+        if (autoSizeKey) dispatch("autosizeReady", { key: autoSizeKey, fontSize })
+        if (hideUntilAutosized) requestAnimationFrame(() => (hideUntilAutosized = false))
+    }
+
+    // determine whether we should keep the visible textbox hidden while autosize runs
+    function shouldHideUntilAutoSizeCompletes() {
+        if (isStage || preview) return false
+        const type = item?.type || "text"
+        if (type !== "text") return false
+        if (!item?.auto) return false
+        // if we already have an autosized font available, no need to hide
+        if (item?.autoFontSize) return false
+        return true
     }
 
     function setItemAutoFontSize(fontSize) {
@@ -371,6 +480,7 @@
     class:chords={chordLines.length}
     class:clickable={$currentWindow === "output" && (item.button?.press || item.button?.release)}
     class:reveal={(centerPreview || isStage) && item.clickReveal && !clickRevealed}
+    class:autoSizingHidden={hideUntilAutosized}
     bind:this={itemElem}
     on:mousedown={press}
     on:mouseup={release}
@@ -438,6 +548,11 @@
     }
     .clickable:active {
         filter: brightness(0.8);
+    }
+
+    .item.autoSizingHidden {
+        visibility: hidden;
+        opacity: 0;
     }
 
     .white {

--- a/src/frontend/components/slide/autosizeCache.ts
+++ b/src/frontend/components/slide/autosizeCache.ts
@@ -1,0 +1,24 @@
+export interface AutoSizeCacheEntry {
+    signature: string
+    fontSize: number
+}
+
+const autoSizeCache = new Map<string, AutoSizeCacheEntry>()
+
+export function readAutoSizeCache(key: string) {
+    if (!key) return undefined
+    return autoSizeCache.get(key)
+}
+
+export function writeAutoSizeCache(key: string, entry: AutoSizeCacheEntry) {
+    if (!key) return
+    autoSizeCache.set(key, entry)
+}
+
+export function clearAutoSizeCache(key?: string) {
+    if (!key) {
+        autoSizeCache.clear()
+        return
+    }
+    autoSizeCache.delete(key)
+}


### PR DESCRIPTION
Hi @vassbo 
As promissed, this is my second attempt to optimize the auto-size, to remove the visible delay on slide change when auto-size is enabled on any text box. 

Here is a brief summary of what we did:

We speeded up textbox autosizing by building it in stages. First we let each textbox hide itself until autosize finished, and we cached the measured font size so revisiting the same slide wouldn’t reflow everything. Next we pre-rendered hidden textboxes ahead of time so the cache was warm before the slide went live, and we stripped the old transition delay that was masking the work. We also had to fix style overrides by clearing any stale font sizes on template items and sharing the autosize cache across every output, so the secondary slide feed reuses the same measurements as the main screen.


I did a bunch of testing, with slow motion videos, and I was unable to observe the issue you were seeing last week, where the font was briefly appearing super big on the screen.

Let me know what you think of this new approach. Seems very quick on all my tests. 