### PR TITLE
Show all Bible versions in collections

### DIFF
--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -39,6 +39,107 @@
     // timeout is to load drawer tab "instantly", before loading scripture
     $: setTimeout(() => loadScripture(previewBibleId), 10)
 
+    // Load all scriptures in collection for multi-version display
+    $: if (isCollection) {
+        activeScriptures.forEach(id => {
+            if (id && !data[id]) {
+                loadScriptureForCollection(id)
+            }
+        })
+    }
+
+    async function loadScriptureForCollection(id: string) {
+        if (!id || data[id]) return
+        try {
+            const jsonBible = await loadJsonBible(id)
+            data[id] = { bibleData: jsonBible }
+            data = data // trigger reactivity
+        } catch (err) {
+            console.error("Error loading collection scripture:", id, err)
+        }
+    }
+
+    // Load book/chapter data for all collection scriptures when navigating
+    async function loadCollectionBookChapter() {
+        if (!isCollection || !activeReference.book || !activeReference.chapters.length) return
+
+        for (const scriptureId of activeScriptures) {
+            if (scriptureId === previewBibleId) continue // already loaded by main flow
+            if (!data[scriptureId]?.bibleData) continue
+
+            try {
+                // Load book if not loaded
+                if (!data[scriptureId].bookData) {
+                    data[scriptureId].bookData = await data[scriptureId].bibleData!.getBook(activeReference.book)
+                }
+                // Load chapter if not loaded
+                if (!data[scriptureId].chapterData && data[scriptureId].bookData) {
+                    data[scriptureId].chapterData = await data[scriptureId].bookData!.getChapter(Number(activeReference.chapters[0]))
+                }
+                data = data // trigger reactivity
+            } catch (err) {
+                console.error("Error loading collection book/chapter:", scriptureId, err)
+            }
+        }
+    }
+
+    // Trigger loading book/chapter for all collection scriptures when reference changes
+    $: if (isCollection && activeReference.book && activeReference.chapters.length) {
+        loadCollectionBookChapter()
+    }
+
+    // Generate dynamic colors for Bible versions that match FreeShow's theme
+    // Uses HSL to create evenly distributed, vibrant colors on dark background
+    function getVersionColor(index: number): string {
+        // Start with FreeShow's secondary pink (330°), then distribute other hues evenly
+        // Offset each subsequent color by golden angle (~137.5°) for good visual separation
+        const goldenAngle = 137.508
+        const baseHue = 330 // FreeShow's pink
+        const hue = (baseHue + index * goldenAngle) % 360
+
+        // High saturation (70-85%) and medium-high lightness (60-70%) for vibrant colors on dark bg
+        const saturation = 75
+        const lightness = 65
+
+        return `hsl(${hue}, ${saturation}%, ${lightness}%)`
+    }
+
+    // Generate a subtle background color (same hue but very transparent)
+    function getVersionBgColor(index: number): string {
+        const goldenAngle = 137.508
+        const baseHue = 330
+        const hue = (baseHue + index * goldenAngle) % 360
+        return `hsla(${hue}, 70%, 50%, 0.12)`
+    }
+
+    // Get verses for all scriptures in a collection
+    function getCollectionVerses(verseNumber: number): { id: string; name: string; text: string }[] {
+        if (!isCollection) return []
+        return activeScriptures
+            .map(scriptureId => {
+                const scriptureData = data[scriptureId]
+                const scriptureMeta = $scriptures[scriptureId]
+
+                // Get verse from chapterData
+                let verseText = ""
+                if (scriptureData?.chapterData) {
+                    try {
+                        const verse = scriptureData.chapterData.getVerse(verseNumber)
+                        verseText = verse?.getHTML?.() || verse?.data?.text || ""
+                    } catch {
+                        // Verse might not exist in this translation
+                    }
+                }
+
+                return {
+                    id: scriptureId,
+                    name: scriptureMeta?.customName || scriptureMeta?.name || scriptureId,
+                    text: verseText
+                }
+            })
+            .filter(v => v.text)
+    }
+
     $: isActiveInOutput = outputIsScripture($outputs)
 
     type Reference = {
@@ -786,6 +887,7 @@
                                 {@const verseLabel = buildVerseLabel(id, subverse, endNumber, showSplitSuffix)}
                                 {@const isActive = activeReference.verses[activeReference.verses.length - 1]?.find(vid => vid.toString() === content.id || vid.toString() === id.toString())}
                                 {@const text = formatBibleText(content.text, true)}
+                                {@const collectionVerses = isCollection && $scriptureMode !== "grid" ? getCollectionVerses(id) : []}
 
                                 <!-- custom drag -->
                                 <span
@@ -793,6 +895,7 @@
                                     class="verse"
                                     class:showAllText={$resized.rightPanelDrawer <= 5}
                                     class:isActive
+                                    class:collection-verse={isCollection && $scriptureMode !== "grid"}
                                     data-title="{text}<br><br>{translateText('tooltip.scripture')}"
                                     draggable="true"
                                     on:mousedown={e => openVerse(updateVersesSelection(e, content.id))}
@@ -808,7 +911,18 @@
                                     </span>
 
                                     {#if $scriptureMode !== "grid"}
-                                        {@html text}
+                                        {#if isCollection && collectionVerses.length > 1}
+                                            <!-- Show all versions for collections -->
+                                            <div class="collection-versions">
+                                                {#each collectionVerses as cv, cvIndex}
+                                                    <div class="version-item" style="--version-color: {getVersionColor(cvIndex)}; --version-bg: {getVersionBgColor(cvIndex)}">
+                                                        <span class="version-text">{@html formatBibleText(cv.text, true)}</span>
+                                                    </div>
+                                                {/each}
+                                            </div>
+                                        {:else}
+                                            {@html text}
+                                        {/if}
                                     {/if}
                                 </span>
                             {/each}
@@ -1073,5 +1187,48 @@
     .grid .verses {
         color: var(--secondary);
         font-weight: bold;
+    }
+
+    /* Collection multi-version display */
+    .verse.collection-verse {
+        display: block !important;
+        flex: none !important;
+        height: auto !important;
+        min-height: 0 !important;
+        padding: 2px 10px 2px 0 !important;
+        margin: 0 !important;
+        white-space: normal !important;
+        overflow: visible !important;
+        text-overflow: unset !important;
+    }
+
+    .collection-versions {
+        display: block !important;
+        width: 100%;
+        padding: 0 !important;
+        margin: 2px 0 0 0 !important;
+    }
+
+    .version-item {
+        display: block !important;
+        padding: 3px 6px 3px 8px !important;
+        margin: 0 0 2px 0 !important;
+        border-left: 4px solid var(--version-color, var(--secondary));
+        background: var(--version-bg, transparent);
+        border-radius: 0 4px 4px 0;
+        line-height: 1.2;
+    }
+
+    .version-item:last-child {
+        margin-bottom: 0 !important;
+    }
+
+    .version-text {
+        display: inline !important;
+        font-size: 0.9em;
+        line-height: 1.2;
+        font-weight: normal;
+        padding: 0 !important;
+        margin: 0 !important;
     }
 </style>


### PR DESCRIPTION
### Summary
When using Bible collections, this update displays all translation versions for each verse simultaneously in the verse selection UI, instead of showing only one version at a time.

### Changes
- **Main app**: Modified verse display in collections to show all versions stacked per verse
- **Remote viewer**: Same multi-version display for the web remote (localhost:5510)
- **Visual distinction**: Each translation has a unique color-coded left border using dynamically generated colors that match FreeShow's theme
- **Compact layout**: Removed padding and translation labels for a cleaner look while keeping verse numbers

### Why
When comparing translations or preparing slides with multiple Bible versions, users can now see all versions at a glance without switching between them. This makes it easier to select the right verse when following the preachers who use different languages. 

### Screenshots
<img width="678" height="896" alt="Screenshot 2025-11-30 at 8 05 10 PM" src="https://github.com/user-attachments/assets/12be06ba-89ff-4f5a-8bc8-5eb73d61a037" />
<img width="1646" height="896" alt="Screenshot 2025-11-30 at 8 58 22 PM" src="https://github.com/user-attachments/assets/4fda03c5-dc64-47aa-ae49-bd3d9a356861" />
<img width="603" height="1311" alt="FreeShow Remote" src="https://github.com/user-attachments/assets/8021c020-e1a0-4ca1-8cc1-a2b0674e1bf5" />


### Testing
- Tested with 3-version and 2-version Bible collections
- Single Bible selection still works as before
- Grid mode unaffected (feature only applies to list mode)
- Remote viewer displays correctly
