### PR TITLE
Add avahi-control plug to snapcraft.yaml

### DIFF
--- a/config/building/snapcraft.yaml
+++ b/config/building/snapcraft.yaml
@@ -48,6 +48,7 @@ apps:
         plugs:
             - alsa
             - audio-playback
+            - avahi-control
             - browser-support
             - camera
             - desktop


### PR DESCRIPTION
This is the final piece to enable NDI on the snap.