### PR TITLE
Allways suffix on grid view

### DIFF
--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -1177,6 +1177,11 @@
 
         font-weight: 600;
     }
+    .grid .verses .v span {
+        display: inline;
+        flex: none;
+        min-width: 0;
+    }
     .grid .books span {
         min-width: 52px;
     }


### PR DESCRIPTION
This makes it so that when in grid mode, we always display the letter suffix on the grid. 

Stil respects the "Show letter suffix" toggle on the slides itself, but on the verse picker, we should always show the suffix)