### PR TITLE
Fix song number search to support alphanumeric values

### DIFF
--- a/src/frontend/utils/search.ts
+++ b/src/frontend/utils/search.ts
@@ -54,9 +54,11 @@ export function showSearchFilter(searchValue: string, show: ShowList) {
 
     // WIP tag search?
 
-    // Priority 0: Number Exact Match
+    // Priority 0: Song Number Exact Match (supports alphanumeric like "MP133")
     const songNumber: string = show.quickAccess?.number || ""
-    if (songNumber && Number(songNumber) === Number(searchValue)) return 100
+    const formattedSongNumber = formatSearch(songNumber, true)
+    const formattedSearchValue = formatSearch(searchValue, true)
+    if (songNumber && formattedSongNumber === formattedSearchValue) return 100
     // Priority 0.5: CCLI Exact Match
     const songId = show.quickAccess?.metadata?.CCLI || ""
     if (songId.toString() === searchValue) return 100
@@ -65,7 +67,6 @@ export function showSearchFilter(searchValue: string, show: ShowList) {
     const showNameWithNumber = songNumber + showName
 
     // Priority 1: Title Exact Match
-    const formattedSearchValue = formatSearch(searchValue, true)
     if (formattedSearchValue === showName || formattedSearchValue === showNameWithNumber) return 100
 
     // Priority 1.5: Title Word Start Match


### PR DESCRIPTION
I noticed that the search wasn't really working as expected, when alphanumeric song numbers:


Before this commit:
<img width="837" height="367" alt="image" src="https://github.com/user-attachments/assets/5d5e5ea1-de4f-4c00-822a-b8a14a5accca" />


After this commit:
<img width="1205" height="481" alt="image" src="https://github.com/user-attachments/assets/5b3dd147-6f58-4690-b103-a6dbaae9b804" />




I don't think this breaks any current feature. at least not from my tests. 