### PR TITLE
Added additional metadata when importing soft projector songs

### DIFF
--- a/src/frontend/converters/softprojector.ts
+++ b/src/frontend/converters/softprojector.ts
@@ -60,7 +60,11 @@ export function convertSoftProjector(data: any) {
 
         show.meta = {
             number: song.number || "",
-            title: song.title || ""
+            title: song.title || "",
+            author: song.words || "",
+            composer: song.music || "",
+            note: song.notes || "",
+            key: song.tune || ""
         }
         if (show.meta.number !== undefined) show.quickAccess = { number: show.meta.number }
 


### PR DESCRIPTION
# Added additional metadata when importing soft projector songs

## Motivation
When importing songs from the SoftProjector format, FreeShow ignores all data about song besides number and title. With this new change, FreeShow will be able import the following additional metadata for each song from SoftProjector:

* Author (mapped by `words` field in SoftProjector)
* Composer (mapped by `music` field in SoftProjector)
* Key (mapped by `tune` field in SoftProjector)
* Note (mapped by `notes` field in SoftProjector, useful  for storing custom messages about a song)

All these fields are resolved to an empty string if they are not present in SoftProjector.



