### PR TITLE
Fix null font-size handling in style overwrites

### DIFF
--- a/src/frontend/components/slide/wordOverride.ts
+++ b/src/frontend/components/slide/wordOverride.ts
@@ -96,10 +96,11 @@ function mergeOverrideStyles(baseStyle: string, override: TemplateStyleOverride)
 
 function getRelativeFontSize(baseStyle: string, templateStyle: string) {
     let templateFontSize = templateStyle.match(/font-size:\s*(\d+)px/)
-    let baseFontSize = baseStyle.match(/font-size:\s*(\d+)px/)
-    if (!templateFontSize && !baseFontSize) return 100
-    if (!templateFontSize) return Number(baseFontSize![1])
+    let baseFontSize = baseStyle?.match(/font-size:\s*(\d+)px/)
+    if (!templateFontSize && !baseFontSize) return null
+    if (!baseFontSize) return Number(templateFontSize![1])
+    if (!templateFontSize) return Number(baseFontSize[1])
 
-    let percentageDiff = Number(templateFontSize[1]) / Number(baseFontSize![1])
-    return Number(baseFontSize![1]) * percentageDiff
+    let percentageDiff = Number(templateFontSize[1]) / Number(baseFontSize[1])
+    return Number(baseFontSize[1]) * percentageDiff
 }


### PR DESCRIPTION
This fixes a crash, when a style overwrite was created without editing the font size. 

The issue was:

Missing null check on baseStyle: 
If baseStyle was null or undefined, calling .match() on it would fail
Missing null check for baseFontSize: The code checked if templateFontSize was null, but then still tried to access baseFontSize![1] even when baseFontSize could also be null


Changes made:
Added optional chaining to handle cases where baseStyle is null/undefined
Added a check for when baseFontSize is null but templateFontSize exists - now it returns the template font size
Changed the return value from 100 to null when neither has a font-size, so it doesn't add an invalid font-size style