### PR TITLE
fix next slide indexing

### DIFF
--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -776,7 +776,7 @@
         if (!activeReference.book) return
 
         // Check if we're dealing with split verses
-        const currentVerses = activeReference.verses[0] || []
+        const currentVerses = [...(activeReference.verses[0] || [])].sort()
         const currentVerseId = currentVerses[0]?.toString()
         const selectionCount = currentVerses.length
         if (currentVerseId && splittedVerses.length) {


### PR DESCRIPTION
The `currentVerses` list wasn't always holding sorted values, but the algorithm assumed it was. So now the list is sorted initially. ToDo: look for other related sensitive places in code.

Reference for the issue discussion: https://livechurchsolutions.slack.com/archives/C074Q696S8L/p1766584600906569