### PR TITLE
Fix verse 1 duplication when split by 'Split long verses' feature

### DIFF
--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -449,6 +449,17 @@
         if (keys || !selectedVerses[selectedVerses.length - 1]?.find((a) => a && (a.toString() === verseNumber || a === getVerseId(verseNumber)))) {
             selectedVerses[selectedVerses.length - 1] = scriptureRangeSelect(e, selectedVerses[selectedVerses.length - 1], verseNumber, splittedVerses)
 
+            // Remove plain verse IDs if split versions exist (e.g., remove "1" if "1_1", "1_2" are present)
+            const currentSelection = selectedVerses[selectedVerses.length - 1]
+            const splitVerseIds = currentSelection.filter(id => id.toString().includes("_"))
+            if (splitVerseIds.length > 0) {
+                const baseIdsToRemove = new Set(splitVerseIds.map(id => id.toString().split("_")[0]))
+                selectedVerses[selectedVerses.length - 1] = currentSelection.filter(id => {
+                    const idStr = id.toString()
+                    return idStr.includes("_") || !baseIdsToRemove.has(idStr)
+                })
+            }
+
             // deselecting a verse
             if (!selectedVerses[selectedVerses.length - 1]?.find((id) => id.toString() === verseNumber)) {
                 previousSelection = clone(selectedVerses[selectedVerses.length - 1])


### PR DESCRIPTION
When clicking a book name to auto-focus on verse 1, then shift-clicking to extend the selection, verse 1 would appear twice if it was split into multiple parts (1_1, 1_2, etc).

<img width="1594" height="282" alt="image" src="https://github.com/user-attachments/assets/d944cc76-66c4-41ba-b310-cc5b9e53382f" />



## The Issue
When you clicked on a Bible book name (like "Numbers"), FreeShow would automatically focus on Chapter 1, Verse 1. If you then scrolled down and shift-clicked on verse 8 to select a range, verse 1 appeared twice in the slides - once as a complete verse, and again split into parts.

## What Was Happening

Auto-focus happened first: When user clicked the book name, the system immediately set the selection to plain [1] (not split yet, because verses hadn't been loaded)

Verses loaded and split: Then the verses loaded, and the system realized verse 1 was too long, so it created 1_1 and 1_2 instead of plain 1

Range selection mixed them: When user shift-clicked verse 8, the range selection saw:

Starting point: 1 (from the auto-focus)
Available verses: ["1_1", "1_2", "2", "3", ...] (from the split feature)
Result: ["1", "1_1", "1_2", "2", "3", ...] - both the plain and split versions!
Slides created duplicates: When converting to slides, it created slides for both plain verse 1 AND the split parts, causing the duplication.

## The Fix
After the range selection is calculated, the fix checks: "Are there any split verse IDs (containing _) in the selection?" If yes, it removes the plain version of those verses.

For example:

Before fix: ["1", "1_1", "1_2", "2", "3", ...]
After fix: ["1_1", "1_2", "2", "3", ...] (plain 1 removed because 1_1 and 1_2 exist)
This ensures each verse only appears once in the final slides, in the correct format (split if needed, plain if not).