### PR TITLE
Fix duplicate font-family in template editor CSS

### DIFF
--- a/src/frontend/components/edit/scripts/textStyle.ts
+++ b/src/frontend/components/edit/scripts/textStyle.ts
@@ -75,9 +75,9 @@ export function addStyleString(oldStyle: string, style: any[]): string {
     let array: string[] = oldStyle.split(";")
     // remove last if empty
     if (!array[array.length - 1].length) array.pop()
-    // remove old styles
-    array.forEach((s, i) => {
-        if (s.split(":")[0].trim() === style[0] || !s.length) array.splice(i, 1)
+    // remove old styles using filter to avoid index issues
+    array = array.filter((s) => {
+        return s.split(":")[0].trim() !== style[0] && s.length > 0
     })
 
     // remove font if changing family


### PR DESCRIPTION
Fixes https://github.com/ChurchApps/FreeShow/issues/2671 where changing font-family in template editor with multiple lines would add a new font-family property instead of replacing the old one. 

Replaced forEach with splice approach (which had index-skipping issues) with a filter method to properly remove old style properties.