### PR TITLE
Fix OpenSong importer: trim whitespace from section tags

### DIFF
--- a/src/frontend/converters/opensong.ts
+++ b/src/frontend/converters/opensong.ts
@@ -97,6 +97,7 @@ function createSlides({ lyrics, presentation, backgrounds }: Song) {
             .split("\n")
             .splice(0, 1)[0]
             ?.replace(/[\[\]]/g, "")
+            .trim()
         if (group.startsWith(".")) group = "V"
         if (!groupText) return
 


### PR DESCRIPTION
The OpenSong importer was failing to import certain songs correctly when section tags contained whitespace after the tag (e.g., `[V1] ` or `[C] ` instead of `[V1]` and `[C]`).

Added `.trim()` to normalize group names after extracting them from brackets. This ensures consistent matching regardless of whitespace variations in the OpenSong XML file.