### PR TITLE
Fix grow to fit not working

### DIFF
--- a/src/frontend/components/slide/Textbox.svelte
+++ b/src/frontend/components/slide/Textbox.svelte
@@ -406,7 +406,7 @@
             customTypeRatio = verseItemSize / 100 || 1
 
             defaultFontSize = itemFontSize
-            if (textFit === "growToFit" && isTextItem) maxFontSize = itemFontSize
+            if (textFit === "growToFit" && isTextItem && itemFontSize > 100) maxFontSize = itemFontSize
         }
 
         let elem = itemElem


### PR DESCRIPTION
This fixes the regression introduced on 1.5.6 (https://github.com/ChurchApps/FreeShow/issues/2709) that broke the grow to fit if font-size was bigger than 100. 

Root Cause: 
In `Textbox.svelte`  when `textFit === "growToFit"` was set for text items, the code was always setting `maxFontSize = itemFontSize` (which defaults to 100px). This caused the binary search algorithm to only search between 10px-100px, preventing text from growing larger.