### PR TITLE
fix wrong Item ordering on unchanged items

### DIFF
--- a/src/frontend/components/output/layers/SlideContent.svelte
+++ b/src/frontend/components/output/layers/SlideContent.svelte
@@ -44,8 +44,9 @@
     let current: any = {}
     let show = false
 
-    // Track which items should skip transition (unchanged content, no real transition)
-    let itemsShouldSkipTransition: boolean[] = []
+    // Track items that are unchanged between slides and have no transition (to avoid redraw flicker)
+    let persistentItems: Item[] = []
+    let persistentItemIndexes: number[] = []
 
     // Check if a transition is "meaningful" (not none and duration > 0)
     function hasRealTransition(itemTransition: Transition | undefined, globalTrans: Transition | undefined): boolean {
@@ -155,7 +156,9 @@
         if (!currentSlideItems?.length) {
             scheduleAutoSizePrecompute([])
             currentItems = []
-            itemsShouldSkipTransition = []
+            // Clear persistent items when no slide content
+            persistentItems = []
+            persistentItemIndexes = []
             current = {
                 outSlide: clone(outSlide),
                 slideData: clone(slideData),
@@ -185,30 +188,49 @@
         let currentTransitionDuration = transitionEnabled ? (itemTransitionDuration ?? currentTransition?.duration ?? 0) : 0
         let waitToShow = currentTransitionDuration * 0.5
 
+        // Identify items that are unchanged and have no real transition (to skip redraw)
+        const newPersistentIndexes: number[] = []
+        const newPersistentItems: Item[] = []
+        const transitioningItems: Item[] = []
+        const transitioningIndexes: number[] = []
+
         // First, check if ANY item on the slide has a real transition
-        // If so, all items should animate together
+        // If so, all items should animate together (no persistent items)
         const slideHasAnyTransition = currentSlide.items.some((item: Item) => {
             const itemTrans = item.actions?.transition
             return hasRealTransition(itemTrans, currentTransition)
         })
 
-        // Determine which items can skip transition (unchanged content, no transition, and no other items transitioning)
-        const newItemsShouldSkipTransition: boolean[] = currentSlide.items.map((newItem: Item, newIndex: number) => {
+        currentSlide.items.forEach((newItem: Item, newIndex: number) => {
+            // Find matching old item by index (position-based matching for slides)
             const oldItem = currentItems[newIndex]
-            // Item can skip transition only if:
+
+            // Item is persistent only if:
             // 1. Content is unchanged AND
             // 2. No real transition on this item AND
             // 3. No other item on the slide has a transition (so whole slide animates together)
-            return itemsAreEqual(oldItem, newItem) && !slideHasAnyTransition
+            if (itemsAreEqual(oldItem, newItem) && !slideHasAnyTransition) {
+                newPersistentIndexes.push(newIndex)
+                newPersistentItems.push(clone(newItem))
+            } else {
+                // Item needs to be re-rendered (changed, has transition, or another item has transition)
+                transitioningIndexes.push(newIndex)
+                transitioningItems.push(clone(newItem))
+            }
         })
+
+        // Update persistent items (these won't flash)
+        persistentItemIndexes = newPersistentIndexes
+        persistentItems = newPersistentItems
 
         // between
         if (currentItems.length && currentSlide.items.length) transitioningBetween = true
 
         if (timeout) clearTimeout(timeout)
 
-        // If all items can skip transition (unchanged), just update context without triggering show/hide cycle
-        if (newItemsShouldSkipTransition.every(skip => skip)) {
+        // If all items are persistent (unchanged), skip the show/hide cycle entirely
+        if (transitioningItems.length === 0 && persistentItems.length > 0) {
+            // Just update the context without triggering transitions
             current = {
                 outSlide: clone(outSlide),
                 slideData: clone(slideData),
@@ -216,8 +238,8 @@
                 lines: clone(lines),
                 currentStyle: clone(currentStyle)
             }
+            // Keep currentItems in sync but don't toggle show
             currentItems = clone(currentSlide.items || [])
-            itemsShouldSkipTransition = newItemsShouldSkipTransition
             transitioningBetween = false
             return
         }
@@ -228,8 +250,9 @@
 
             // wait for previous items to start fading out (svelte will keep them until the transition is done!)
             timeout = setTimeout(() => {
+                // Only include items that need transitioning in currentItems
+                // Persistent items are rendered separately
                 currentItems = clone(currentSlide.items || [])
-                itemsShouldSkipTransition = newItemsShouldSkipTransition
                 current = {
                     outSlide: clone(outSlide),
                     slideData: clone(slideData),
@@ -252,13 +275,11 @@
     }
 </script>
 
-
-<!-- Render all items maintaining their original z-order -->
-<!-- Items that don't need transitions are rendered outside {#key} to avoid flicker, but with explicit z-index to maintain layering -->
+<!-- Render all items in original order to maintain z-index layering -->
 {#each currentItems as item, index}
-    {#if itemsShouldSkipTransition[index] && shouldItemBeShown(item, currentItems, showItemRef, updater) && (!item.clickReveal || current.outSlide?.itemClickReveal)}
-        <!-- Item unchanged: render directly without {#key} to avoid flicker, with z-index to preserve order -->
-        <div style="position: relative; z-index: {index};">
+    {#if shouldItemBeShown(item, currentItems, showItemRef, updater) && (!item.clickReveal || current.outSlide?.itemClickReveal)}
+        {#if persistentItemIndexes.includes(index)}
+            <!-- Persistent item: unchanged content, render outside transition to avoid flicker -->
             <Textbox
                 backdropFilter={current.slideData?.["backdrop-filter"] || ""}
                 disableListTransition={mirror}
@@ -279,42 +300,37 @@
                 {styleIdOverride}
                 autoSizeKey={createAutoSizeKey(item, index)}
             />
-        </div>
+        {:else}
+            <!-- Transitioning item: render with animation wrapper inside {#key} -->
+            {#key show}
+                {#if show}
+                    <SlideItemTransition {preview} {transitionEnabled} {transitioningBetween} globalTransition={transition} currentSlide={current.currentSlide} {item} outSlide={current.outSlide} lines={current.lines} currentStyle={current.currentStyle} let:customSlide let:customItem let:customLines let:customOut let:transition>
+                        <Textbox
+                            backdropFilter={current.slideData?.["backdrop-filter"] || ""}
+                            disableListTransition={mirror}
+                            chords={customItem.chords?.enabled}
+                            animationStyle={animationData.style || {}}
+                            item={customItem}
+                            {transition}
+                            {ratio}
+                            {outputId}
+                            ref={{ showId: customOut?.id, slideId: customSlide?.id, id: customSlide?.id || "", layoutId: customOut?.layout }}
+                            linesStart={customLines?.[currentLineId || ""]?.[item.lineReveal ? "linesStart" : "start"]}
+                            linesEnd={customLines?.[currentLineId || ""]?.[item.lineReveal ? "linesEnd" : "end"]}
+                            clickRevealed={!!customLines?.[currentLineId || ""]?.clickRevealed}
+                            outputStyle={current.currentStyle}
+                            {mirror}
+                            {preview}
+                            slideIndex={customOut?.index}
+                            {styleIdOverride}
+                            autoSizeKey={createAutoSizeKey(item, index)}
+                        />
+                    </SlideItemTransition>
+                {/if}
+            {/key}
+        {/if}
     {/if}
 {/each}
-
-<!-- Transitioning items: rendered inside {#key} for proper animation, with z-index to preserve order -->
-{#key show}
-    {#each currentItems as item, index}
-        {#if show && !itemsShouldSkipTransition[index] && shouldItemBeShown(item, currentItems, showItemRef, updater) && (!item.clickReveal || current.outSlide?.itemClickReveal)}
-            <div style="position: relative; z-index: {index};">
-                <SlideItemTransition {preview} {transitionEnabled} {transitioningBetween} globalTransition={transition} currentSlide={current.currentSlide} {item} outSlide={current.outSlide} lines={current.lines} currentStyle={current.currentStyle} let:customSlide let:customItem let:customLines let:customOut let:transition>
-                    <Textbox
-                        backdropFilter={current.slideData?.["backdrop-filter"] || ""}
-                        disableListTransition={mirror}
-                        chords={customItem.chords?.enabled}
-                        animationStyle={animationData.style || {}}
-                        item={customItem}
-                        {transition}
-                        {ratio}
-                        {outputId}
-                        ref={{ showId: customOut?.id, slideId: customSlide?.id, id: customSlide?.id || "", layoutId: customOut?.layout }}
-                        linesStart={customLines?.[currentLineId || ""]?.[item.lineReveal ? "linesStart" : "start"]}
-                        linesEnd={customLines?.[currentLineId || ""]?.[item.lineReveal ? "linesEnd" : "end"]}
-                        clickRevealed={!!customLines?.[currentLineId || ""]?.clickRevealed}
-                        outputStyle={current.currentStyle}
-                        {mirror}
-                        {preview}
-                        slideIndex={customOut?.index}
-                        {styleIdOverride}
-                        autoSizeKey={createAutoSizeKey(item, index)}
-                    />
-                </SlideItemTransition>
-            </div>
-        {/if}
-    {/each}
-{/key}
-
 
 {#if precomputeTargets.length}
     <div class="autosize-precompute" aria-hidden="true">


### PR DESCRIPTION
This fixes https://github.com/ChurchApps/FreeShow/issues/2661

Items that had text that didn't change between slides were being marked as static, and therefore were not being redrawn on slide transitions. 
Now, this fix makes it so that:
- Render all items in single loop in original order to maintain order of elements
- Unchanged items render without {#key} wrapper to prevent flashing when there are no animations set
- Transitioning items render with {#key} wrapper for proper animations