### PR TITLE
Chordpro import improvements

### DIFF
--- a/src/frontend/converters/chordpro.ts
+++ b/src/frontend/converters/chordpro.ts
@@ -164,8 +164,9 @@ export function convertChordPro(data: any) {
                 let isChord = false
                 let letterIndex = 0
                 line = line.replaceAll("[/]", " ").replaceAll("[|]", "")
+                const isDirectiveLine = line.trim().startsWith("{") && line.includes(":")
                 line.split("").forEach((char) => {
-                    if ((char === "[" || char === "]") && !line.slice(0, -2).includes(":")) {
+                    if ((char === "[" || char === "]") && !isDirectiveLine) {
                         isChord = char === "["
                         if (isChord) chords.push({ id: uid(5), pos: letterIndex, key: "" })
                         return


### PR DESCRIPTION
# PR: Chordpro import improvements

## Summary
Improve ChordPro import reliability by tightening metadata detection, adding support for the `key` field, and keeping chord parsing on lyric lines that include `:`.

## Changes
- Parse metadata only when the key is at the start of the line.
- Accept both `{key: value}` and `Key: value` formats.
- Support `key` in addition to the existing `k` shorthand.
- Keep chord parsing on lyric lines that contain `:` while still ignoring directive lines like `{title: ...}`.

## Examples
### Metadata false match
- Before: `{comment: Chorus}` could overwrite `title` because it contains `t:`.
- After: Only `{title: ...}` or `Title: ...` at line start set the title.

### Chords on lyric lines with colons
- Before: `Sing: [C]Halleluja` could lose chords due to `:`.
- After: Chords are parsed as expected on lyric lines.

### Key metadata
- Before: `{key: A}` ended up in notes.
- After: `{key: A}` is stored as the song key.

## Result
Metadata is filled correctly and chord parsing is more robust, without changing the user-facing format.

