### PR TITLE
fix show delete sync issue

### DIFF
--- a/src/electron/cloud/syncManager.ts
+++ b/src/electron/cloud/syncManager.ts
@@ -175,6 +175,11 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
                             // exists only in cloud
                             const existsLocally = !!localFile
                             if (!existsLocally) {
+                                const lastSeen = CHANGES.modified?.[deviceId] || 0
+                                if (cloudModTime && lastSeen >= cloudModTime) {
+                                    markAsDeleted("SHOWS_CONTENT", fileName)
+                                    return
+                                }
                                 if (isCreated("SHOWS_CONTENT", fileName)) await download()
                                 else markAsDeleted("SHOWS_CONTENT", fileName)
                                 return


### PR DESCRIPTION
## Summary
This change updates the SHOWS merge logic for locally missing shows. Previously, the `created` marker could linger and make a deleted show reappear. Now deletion wins if the current device has already “seen” the show. In ambiguous cases we remain conservative and default to download.

## Changes
- In `syncManager.ts` SHOWS merge, decisions for locally missing shows now compare `lastSeen` vs `cloudModTime`.
- If the device has already seen the show, a missing file means delete (no download).
- If the device has not seen the show, the `created` marker still triggers download.

## Behavior Matrix (When → Then)
- Case A: Show exists in cloud, device has seen it, local file missing → delete (`markAsDeleted`), no download.
- Case B: Show exists in cloud, device has NOT seen it, local missing → download if `created` is set.
- Case C: Show exists in cloud, no `created` marker → delete (`markAsDeleted`).
- Case D: Ambiguous (no `cloudModTime` or no `lastSeen`) → fallback to previous behavior, `created` wins.
- Case E: Offline conflict (both sides changed while offline) → conservative download.

## Why This Is Better
- The previous logic kept `created` until all registered devices had “seen” the show. A stale device could block deletion indefinitely.
- The new rule allows deletion only when the current device has actually seen the show. This matches user expectations: if I already downloaded it and now delete it, it should not come back.
- In ambiguous cases we stay conservative to avoid losing offline work.

## Result
Deleted shows no longer reappear once a device has seen them. Ambiguous or offline conflict cases remain conservative to avoid data loss.

## Tests / Verification
1. A creates a show → B syncs → B deletes → B syncs: the show does not come back.
2. A creates a show → B has never synced: the missing show is downloaded.
3. Offline conflict: A creates, B deletes offline, then syncs: download occurs.
4. Stale `created` marker with a device that already saw the show: deletion applies.

## Assumptions
- The change only affects the SHOWS merge logic in `syncManager.ts` and does not alter data format.
- `lastSeen` is derived from `CHANGES.modified[deviceId]` and is updated on each sync.

Fixes: #2728 #2746 

