### PR TITLE
feat: Add tolerance setting for scripture verse splitting

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1441,6 +1441,7 @@
         "verses_on_individual_lines": "Verses on individual lines",
         "divide_long_verses": "Split long verses",
         "split_long_verses_suffix": "Show letter suffix",
+        "tolerance": "Tolerance",
         "version": "Show version",
         "reference": "Show reference",
         "split_reference": "Split reference",

--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -1090,10 +1090,11 @@ export function getSplittedVerses(verses: { [key: string]: string }) {
     if (!get(scriptureSettings).splitLongVerses) return verses || {}
 
     const chars = Number(get(scriptureSettings).longVersesChars || 100)
+    const tolerance = Number(get(scriptureSettings).longVersesTolerance || 0)
     const newVerses: { [key: string | number]: string } = {}
     Object.keys(verses || {}).forEach((verseKey) => {
         const verse = sanitizeVerseText(verses[verseKey] || "")
-        const newVerseStrings = splitText(verse, chars)
+        const newVerseStrings = splitText(verse, chars, tolerance)
 
         for (let i = 0; i < newVerseStrings.length; i++) {
             const key = newVerseStrings.length === 1 ? "" : `_${i + 1}`
@@ -1104,10 +1105,10 @@ export function getSplittedVerses(verses: { [key: string]: string }) {
     return newVerses
 }
 
-export function splitText(value: string, maxLength: number) {
+export function splitText(value: string, maxLength: number, tolerance: number = 0) {
     if (!value) return []
-    if (/<[^>]+>/.test(value)) return splitHtmlText(value, maxLength)
-    return splitPlainText(value, maxLength)
+    if (/<[^>]+>/.test(value)) return splitHtmlText(value, maxLength, tolerance)
+    return splitPlainText(value, maxLength, tolerance)
 }
 
 const BRACKET_WORD_LIMIT = 4
@@ -1155,7 +1156,7 @@ function moveDanglingBracketToNext(first: string, second: string) {
     return { first: kept, second: combinedSecond }
 }
 
-function splitPlainText(value: string, maxLength: number) {
+function splitPlainText(value: string, maxLength: number, tolerance: number = 0) {
     const queue: string[] = [value.trim()]
     const segments: string[] = []
     const proportion = Math.floor(maxLength * 0.3)
@@ -1173,7 +1174,7 @@ function splitPlainText(value: string, maxLength: number) {
             continue
         }
 
-        const halves = getSplitHalves(current, maxLength)
+        const halves = getSplitHalves(current, maxLength, tolerance)
         if (!halves) {
             segments.push(current)
             continue
@@ -1183,9 +1184,12 @@ function splitPlainText(value: string, maxLength: number) {
 
         ;({ first, second } = moveDanglingBracketToNext(first, second))
 
-        const rebalanced = rebalanceHalves(first, second, maxLength, minSegmentLength)
-        first = rebalanced.first
-        second = rebalanced.second
+        // Only rebalance when tolerance is 0 (to preserve punctuation-based splits)
+        if (tolerance === 0) {
+            const rebalanced = rebalanceHalves(first, second, maxLength, minSegmentLength)
+            first = rebalanced.first
+            second = rebalanced.second
+        }
 
         if (second.length < 1) {
             segments.push(first)
@@ -1203,7 +1207,7 @@ function splitPlainText(value: string, maxLength: number) {
     return segments
 }
 
-function splitHtmlText(value: string, maxLength: number) {
+function splitHtmlText(value: string, maxLength: number, tolerance: number = 0) {
     const tokens = tokenizeHtml(value)
     if (!tokens.length) return [value]
 
@@ -1318,19 +1322,44 @@ function findHtmlSplitIndex(text: string, capacity: number) {
     return Math.max(0, breakPos)
 }
 
-function getSplitHalves(text: string, maxLength: number): [string, string] | null {
-    const halves = splitTextContentInHalf(text)
-    if (halves.length >= 2) {
-        const first = halves[0].trim()
-        const second = halves[1].trim()
-        if (first.length && second.length) return [first, second]
+function getSplitHalves(text: string, maxLength: number, tolerance: number = 0): [string, string] | null {
+    // Only use splitTextContentInHalf when tolerance is 0 (original behavior)
+    if (tolerance === 0) {
+        const halves = splitTextContentInHalf(text)
+        if (halves.length >= 2) {
+            const first = halves[0].trim()
+            const second = halves[1].trim()
+            if (first.length && second.length) {
+                return [first, second]
+            }
+        }
     }
 
     if (text.length <= maxLength) return null
 
-    let pivot = text.lastIndexOf(" ", maxLength)
-    if (pivot <= 0) pivot = text.indexOf(" ", maxLength)
-    if (pivot <= 0) pivot = maxLength
+    let pivot = -1
+    
+    // Only use smart punctuation splitting if tolerance > 0
+    if (tolerance > 0) {
+        const windowMin = maxLength - tolerance
+        const windowMax = Math.min(text.length - 1, maxLength + tolerance)
+        
+        // Search for punctuation ONLY within [windowMin, windowMax]
+        for (let i = windowMin; i <= windowMax; i++) {
+            const ch = text.charAt(i)
+            if (/[.,;:!?]/.test(ch)) {
+                pivot = i + 1
+                break
+            }
+        }
+    }
+    
+    // Original behavior: find space (used when tolerance=0 or no punctuation found)
+    if (pivot === -1) {
+        pivot = text.lastIndexOf(" ", maxLength)
+        if (pivot <= 0) pivot = text.indexOf(" ", maxLength)
+        if (pivot <= 0) pivot = maxLength
+    }
 
     const first = text.slice(0, pivot).trim()
     const second = text.slice(pivot).trim()
@@ -1675,7 +1704,16 @@ export function swapPreviewBible(collectionId: string) {
 // WIP similar to array.ts rangeSelect
 // Custom range selection for scripture verses that handles split verses (e.g., "1_1", "5_2")
 export function scriptureRangeSelect(e: any, currentlySelected: (number | string)[], newSelection: number | string, availableVerses: { id: string }[]): (number | string)[] {
-    if (!e.ctrlKey && !e.metaKey && !e.shiftKey) return [newSelection]
+    if (!e.ctrlKey && !e.metaKey && !e.shiftKey) {
+        // When clicking a verse without modifier keys, select all parts of that verse
+        const baseVerseNumber = newSelection.toString().split('_')[0]
+        const allParts = availableVerses
+            .filter(v => v.id.split('_')[0] === baseVerseNumber)
+            .map(v => v.id)
+        
+        // If this verse has multiple parts, return all of them; otherwise just the clicked verse
+        return allParts.length > 1 ? allParts : [newSelection]
+    }
 
     currentlySelected = currentlySelected.map((id) => id.toString())
     newSelection = newSelection.toString()

--- a/src/frontend/components/drawer/info/ScriptureInfo.svelte
+++ b/src/frontend/components/drawer/info/ScriptureInfo.svelte
@@ -284,6 +284,7 @@
                     {#if $scriptureSettings.splitLongVerses}
                         <MaterialToggleSwitch label="scripture.split_long_verses_suffix" checked={$scriptureSettings.splitLongVersesSuffix} defaultValue={false} on:change={(e) => update("splitLongVersesSuffix", e.detail)} />
                         <MaterialNumberInput label="edit.size" value={$scriptureSettings.longVersesChars || 100} defaultValue={100} min={50} on:change={(e) => update("longVersesChars", e.detail)} />
+                        <MaterialNumberInput label="scripture.tolerance" value={$scriptureSettings.longVersesTolerance || 0} defaultValue={0} min={0} max={100} on:change={(e) => update("longVersesTolerance", e.detail)} />
                     {/if}
                 </svelte:fragment>
             </InputRow>


### PR DESCRIPTION
Currently, when "Split long verses" is enabled, verses are split at arbitrary positions near the character limit (whatever space character is closer to the limit), often breaking mid-sentence or at awkward word boundaries. This creates unnatural reading breaks that can disrupt the flow during presentations.

Example: A 192-character verse with size=160 might split like:


"...trees bearing fruit in which is their seed, each [slide break] according to its kind. And God saw that it was good."

Solution
Added a Tolerance setting (0-100) that enables punctuation-aware splitting:

We search for punctuation marks (., ,, ;, :, !, ?) within a window around the split point
Splits at the punctuation for natural sentence boundaries.
Example:
With size=160 and tolerance=20, it searches positions 140-180 for the best punctuation mark
Same verse with tolerance=20:

"...trees bearing fruit in which is their seed, each according to its kind. [slide break] And God saw that it was good."

Other fix included in this PR:
When clicking any part of a split verse, all parts are now automatically selected (instead of just one part). This prevents users from accidentally adding only half a verse to their show (happened multiple times at my church, where the second half of the last verse was missing... lol) . Users can still Ctrl+Click to deselect individual parts if needed.

If Tolerance = 0 , it maintains exact current behavior - no code changes to existing functionality. Users must opt-in by setting tolerance > 0.

Use Cases
Small tolerance (10-20): Find punctuation near the ideal split point
Large tolerance (40-50): Accept splits further from ideal if it means better punctuation placement
Zero tolerance: Original behavior (space-based splitting with rebalancing)
