### PR TITLE
Fix issue when searching for scripture using the split long verses feature

### DIFF
--- a/src/frontend/components/drawer/bible/Scripture.svelte
+++ b/src/frontend/components/drawer/bible/Scripture.svelte
@@ -553,8 +553,15 @@
             openChapter([result.chapter])
 
             // VERSES
-            if (result.verses.length) openVerse([result.verses])
-            else selectAllTimeout = setTimeout(selectAllVerses)
+            if (result.verses.length) {
+                if (splittedVerses) {
+                    openVerse([splittedVerses.filter((a) => result.verses.includes(a.number)).map((a) => a.id)])
+                } else {
+                    openVerse([result.verses])
+                }
+            } else {
+                selectAllTimeout = setTimeout(selectAllVerses)
+            }
         }
     }
 


### PR DESCRIPTION
When using split long verses the scripture search does not take into account the verse splits. If you do a scripture search which includes the verses and then convert to a show the split long verses is not taken into account.

The fix is to map the searched verses to the calculated split verses.