### PR TITLE
fix(transitions): stabilise existing transition system

### DIFF
--- a/src/frontend/components/output/layers/Background.svelte
+++ b/src/frontend/components/output/layers/Background.svelte
@@ -25,25 +25,17 @@
     let firstFadingOut = false
     let currentlyLoadingFirst = false
 
-    // WIP changing media while another transitions is not smooth
-    // WIP changing quicly between media might make it not receive updates
-
     let loading = false
     let timeout: NodeJS.Timeout | null = null
-    let tooRapid: NodeJS.Timeout | null = null
-    let tryAgain = false
-    $: if (data) createBackground()
-    function createBackground() {
-        // prevent svelte bug creating multiple items if creating new while old clears
-        if (tooRapid) {
-            tryAgain = true
+    let pendingBackground: any = null
+    let isTransitioning = false
+    $: if (data) createBackground(data)
+    function createBackground(bgData: any = data) {
+        if (isTransitioning) {
+            pendingBackground = clone(bgData)
             return
         }
-        tooRapid = setTimeout(() => {
-            tooRapid = null
-            if (tryAgain) createBackground()
-            tryAgain = false
-        }, duration / 2)
+        isTransitioning = true
 
         if (timeout) {
             clearTimeout(timeout)
@@ -52,17 +44,18 @@
         if (loading) loading = false
 
         // clearing
-        if (!data.path && !data.id) {
+        if (!bgData.path && !bgData.id) {
             background1 = null
             background2 = null
+            isTransitioning = false
             return
         }
 
-        let newData = clone(data)
+        let newData = clone(bgData)
 
         // update existing background, if same
         let activeId = firstActive ? background1?.path || background1?.id : background2?.path || background2?.id
-        if (activeId === (data.path || data.id)) {
+        if (activeId === (bgData.path || bgData.id)) {
             if (firstActive) {
                 background1 = newData
                 transition1 = clone(transition)
@@ -70,13 +63,14 @@
                 background2 = newData
                 transition2 = clone(transition)
             }
+            isTransitioning = false
             return
         }
 
         timeout = setTimeout(
             () => {
                 loading = true
-                let loadingFirst = !background1 // && background2?.path ? background2?.path !== data.path : background2?.id !== data.id
+                let loadingFirst = !background1
                 currentlyLoadingFirst = loadingFirst
                 firstFadingOut = !loadingFirst
 
@@ -111,6 +105,13 @@
                 background1 = null
             }
             timeout = null
+
+            isTransitioning = false
+            if (pendingBackground) {
+                const pending = pendingBackground
+                pendingBackground = null
+                createBackground(pending)
+            }
         })
     }
 

--- a/src/frontend/components/output/transitions/SlideItemTransition.svelte
+++ b/src/frontend/components/output/transitions/SlideItemTransition.svelte
@@ -1,11 +1,11 @@
 <script lang="ts">
+    import { onDestroy } from "svelte"
     import { uid } from "uid"
     import type { Item, Transition } from "../../../../types/Show"
     import { currentWindow, scriptureSettings, templates } from "../../../stores"
     import { clone } from "../../helpers/array"
     import { getStyleTemplate, slideHasAutoSizeItem } from "../../helpers/output"
     import OutputTransition from "./OutputTransition.svelte"
-    // import { onMount } from "svelte"
 
     export let globalTransition: Transition
     export let transitionEnabled = false
@@ -18,14 +18,12 @@
     export let currentStyle: any = {}
 
     let currentlyTransitioning: { [key: string]: any } = {}
+    let transitionId = 0
 
     $: if (item !== undefined || lines) startTransition()
 
-    // WIP item wait out time will not clear other items without wait time if between transition
-    // WIP slide direction from top to bottom is a bit buggy
-    // WIP image is flashing a bit in scripture transition none
-
     function startTransition() {
+        const id = ++transitionId
         let itemTransition = item.actions?.transition ? clone(item.actions.transition) : null
         if (itemTransition?.type === "none") itemTransition.duration = 0
 
@@ -66,12 +64,8 @@
             }
         }
 
-        // add some time in case an identical item is "fading" in
-        if (!outDelay && itemTransition?.duration === 0 && item.type === "media") outDelay = 250
-        // the previous fallback kept the old item visible a moment longer to avoid a black flash,
-        // but the autosize precompute path already keeps the new content ready, so we let the
-        // zero-duration case swap immediately to prevent overlapping text.
-        // WIP having outDelay on just 1 item will cause all other items to not clear until that is finished!
+        // add some time in case an identical item is "fading" in (skip for "none" — no animation means no flash risk)
+        if (!outDelay && itemTransition?.duration === 0 && item.type === "media" && transition?.type !== "none") outDelay = 250
 
         // SET DELAY
 
@@ -84,6 +78,9 @@
         if (outDelay && (outTransition.type === "none" || outTransition?.duration === 0)) outTransition = { ...outTransition, type: "fade", duration: 1 }
 
         // console.log(inTransition, outTransition)
+
+        // bail if a newer startTransition() call has already superseded this one
+        if (transitionId !== id) return
 
         // SET
 
@@ -101,6 +98,10 @@
         currentlyTransitioning[stateId] = state
         currentlyTransitioning = currentlyTransitioning
     }
+
+    onDestroy(() => {
+        transitionId++ // cancel any pending startTransition callbacks
+    })
 
     // only update if new ID! Previous is removed, but output should not update until a new value is set
     let currentIds: string[] = []

--- a/src/frontend/utils/transitions.ts
+++ b/src/frontend/utils/transitions.ts
@@ -38,8 +38,8 @@ export const transitions: { [key in TransitionType]: any } = {
 
                 if (direction === "left_right") return `transform: translate(-${pos}%);`
                 if (direction === "right_left") return `transform: translate(${pos}%);`
-                if (direction === "bottom_top") return `transform: translateY(${pos}%);`
-                if (direction === "top_bottom") return `transform: translateY(-${pos}%);`
+                if (direction === "bottom_top") return `transform: translateY(-${pos}%);`
+                if (direction === "top_bottom") return `transform: translateY(${pos}%);`
 
                 return ""
             }


### PR DESCRIPTION
### Summary
Fixes five known bugs in the transition system.
No new behaviour is introduced - this is a pure stability pass on three files.

Closes part of #2169. Related: #1006.

---

## Changes

### `SlideItemTransition.svelte`

- Added a `transitionId` counter so that if `startTransition()` is called
  multiple times in rapid succession (reactive re-runs), only the latest call
  commits state — stale calls bail out early. An `onDestroy` handler increments
  the counter to cancel any in-flight work when the component unmounts. This
  eliminates the rare stuck/broken transition state tracked in #1006.
- Removed the 250ms `outDelay` flash-prevention for media items when the active
  transition type is `none`. The delay served no purpose without an animation
  and caused a visible hold on scripture/image swaps that should be instant.

### `transitions.ts`

- Swapped the Y-axis translate signs for `bottom_top` and `top_bottom` to match
  the established `left_right` / `right_left` horizontal pattern. The vertical
  directions were inverted — selecting `bottom_top` produced top-entry motion
  and vice versa.

### `Background.svelte`

- Replaced the `tooRapid` timer + `tryAgain` boolean with an `isTransitioning`
  flag and a `pendingBackground` slot. Previously, background changes that
  arrived during an active transition were silently discarded (or only retried
  once via `tryAgain`). Now the latest pending change is always queued and
  applied as soon as `loaded()` fires, so rapid slide advances no longer leave
  the background stuck on an earlier slide.

---

## Testing

1. `npm start` — open a scripture show, set transition to **None**, advance
   slides → no black flash
2. Advance slides rapidly (faster than transition duration) → output always
   settles on the correct slide
3. Set transition to **Slide**, test all four directions → `bottom_top` and
   `top_bottom` now enter from the correct sides
4. Advance rapidly through slides with different background images → final
   background is always correct
5. `npx svelte-check --tsconfig ./tsconfig.json` → no new errors