### PR TITLE
Fix/scripture first slide template

### DIFF
--- a/src/frontend/components/drawer/bible/scripture.ts
+++ b/src/frontend/components/drawer/bible/scripture.ts
@@ -899,7 +899,15 @@ export async function getScriptureSlidesNew(data: any, onlyOne = false, disableR
     // match: prepend globalCustomDynamicValues so the reference slide can resolve placeholders
     // like {scripture_reference_full} and {meta_title}, while verse slides keep their own data.
     if (_template.getSetting("firstSlideTemplate") && !onlyOne) {
-        slideDynamicValues = [{ ...globalCustomDynamicValues }, ...slideDynamicValues]
+        // Pad with globalCustomDynamicValues + scripture_text/scripture1_text as the full reference
+        // string, so outputs whose template uses {scripture_text} (e.g. a secondary OBS output that
+        // has no firstSlideTemplate) show the reference instead of a raw placeholder on slide 0.
+        const referenceSliceDV = {
+            ...globalCustomDynamicValues,
+            scripture_text: format(fullReference),
+            scripture1_text: format(fullReference),
+        }
+        slideDynamicValues = [referenceSliceDV, ...slideDynamicValues]
     }
 
     return { slides: newSlides, groupNames, attributions, slideDynamicValues }


### PR DESCRIPTION
fixes https://github.com/ChurchApps/FreeShow/issues/2941

fix 1: align slideDynamicValues with firstSlideTemplate slide
When a scripture template has a "First Slide Template" configured, createSlides() prepends a reference slide at index 0. groupNames was already correctly padded for this extra slide, but slideDynamicValues was not — causing a one-off misalignment: verse 1 was silently consumed into the reference slide's data, every subsequent verse shifted by one, and the last slide was left with its raw {scripture_number}{scripture_text} placeholders.

Fix 2: resolve scripture_text placeholder on reference slide for secondary outputs
Secondary outputs (e.g. OBS) that use a different scripture template — one without a "First Slide Template" but with a {scripture_text} field — were showing the raw placeholder on slide 0. The padded reference-slide entry in slideDynamicValues only contained global string values but no scripture_text. This commit adds scripture_text and scripture1_text as the full reference string (e.g. "Genesis 1:1-8") in that entry, so any template field using {scripture_text} on the reference slide resolves to the reference instead of staying blank.