### PR TITLE
Implement chord chart parsing and update song section handling

### DIFF
--- a/src/electron/contentProviders/planningCenter/request.ts
+++ b/src/electron/contentProviders/planningCenter/request.ts
@@ -21,13 +21,76 @@ const PCO_API_version = 2
 type PCORequestData = {
     scope: PCOScopes
     endpoint: string
-    params?: Record<string, string> // Add params type
+    params?: Record<string, string>
 }
 
 type SongSection = {
     label: string
-    lyrics: string
+    chords: string
     breaks_at?: number
+}
+
+function isLikelyChordLine(line: string): boolean {
+    if (!line.trim()) return false
+    
+    const trimmed = line.trim()
+    
+    const chordPattern = /^[A-G][#b]?(?:m|maj|min|add|sus|aug|dim)?[\d]*(?:\s+[A-G][#b]?(?:m|maj|min|add|sus|aug|dim)?[\d]*)*$/
+    
+    if (chordPattern.test(trimmed)) {
+        return true
+    }
+    
+    const chordSymbols = (trimmed.match(/[A-G][#b]?/g) || []).length
+    const totalChars = trimmed.replace(/\s/g, '').length
+    
+    if (chordSymbols > 0 && (chordSymbols / (totalChars / 2)) > 0.5) {
+        return true
+    }
+    
+    return false
+}
+
+function parseChordChartIntoSections(chordChart: string): SongSection[] {
+    const sections: SongSection[] = []
+    const lines = chordChart.split(/\r?\n/)
+    let currentSectionLabel = ""
+    let currentSectionContent: string[] = []
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i]
+        const trimmed = line.trim()
+
+        const sectionMatch = trimmed.match(/^(VERSO|CORO|PUENTE|INTRO|OUTRO|PRE|ESTRIBILLO|BRIDGE|CHORUS|VERSE|BREAK|INSTRUMENTAL)(\s*\d+)?/i)
+        if (sectionMatch) {
+            if (currentSectionLabel && currentSectionContent.length) {
+                const content = currentSectionContent.join("\n").trim()
+                sections.push({
+                    label: currentSectionLabel,
+                    chords: content
+                })
+            }
+            currentSectionLabel = sectionMatch[0]
+            currentSectionContent = []
+            continue
+        }
+
+        if (isLikelyChordLine(line)) {
+            continue
+        }
+
+        currentSectionContent.push(line)
+    }
+
+    if (currentSectionLabel && currentSectionContent.length) {
+        const content = currentSectionContent.join("\n").trim()
+        sections.push({
+            label: currentSectionLabel,
+            chords: content
+        })
+    }
+
+    return sections
 }
 
 interface ServiceType {
@@ -77,7 +140,6 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
         return null
     }
 
-    // Build the path with query parameters if they exist
     let apiPath = `/${data.scope || "services"}/v${PCO_API_version}/${data.endpoint}`
     if (data.params) {
         const queryParams = new URLSearchParams(data.params).toString()
@@ -89,15 +151,12 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
     return new Promise((resolve) => {
         httpsRequest(PCO_API_URL, apiPath, "GET", headers, {}, (err, result) => {
             if (err) {
-                // handle rate limit
-                // https://developer.planning.center/docs/#/overview/rate-limiting
                 if (err.statusCode === 429) {
                     const retryAfter = parseInt(err?.headers?.["retry-after"], 10) || 2
                     rateLimit(retryAfter)
                     return
                 }
 
-                // console.log(apiPath, err)
                 const message = err.message?.includes("401") ? "Make sure you have created some 'services' in your account!" : err.message
                 sendToMain(ToMain.ALERT, "Could not get data! " + message)
                 return resolve(null)
@@ -105,10 +164,7 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
 
             let resultData = result.data
 
-            // convert to array
             if (!Array.isArray(resultData)) resultData = [resultData]
-
-            // console.debug("PCO Request Result:", apiPath, resultData)
 
             resolve(resultData)
         })
@@ -130,8 +186,6 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
         }
     })
 }
-
-// LOAD SERVICES
 
 const ONE_WEEK_MS = 604800000
 
@@ -207,7 +261,6 @@ async function fetchServicePlans(serviceType: ServiceType) {
         return null
     }
 
-    // Filter for the one week window
     const filteredPlans = servicePlans.filter(({ attributes: a }: any) => {
         if (a.items_count === 0) return false
         const date = new Date(a.sort_date).getTime()
@@ -215,7 +268,6 @@ async function fetchServicePlans(serviceType: ServiceType) {
         return date < today + ONE_WEEK_MS
     })
 
-    // console.debug(`Found ${filteredPlans.length} plans for service type ${serviceType.attributes.name} (${serviceType.id})`)
     return filteredPlans
 }
 
@@ -290,18 +342,24 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
     const song = songArrangement.attributes
     const sequence = item.custom_arrangement_sequence || song.sequence || []
 
-    let sections: SongSection[] =
-        (
-            await pcoRequest({
-                scope: "services",
-                endpoint: `${arrangementEndpoint}/sections`
-            })
-        )[0]?.attributes.sections || []
+    let sections: SongSection[] = []
 
-    if (!sections.length) {
-        sections = sequence.map((id: any) => ({ label: id, lyrics: "" }))
+    if (song.chord_chart) {
+        sections = parseChordChartIntoSections(song.chord_chart)
     } else {
-        sections = sections.map(normalizeSongSection)
+        sections =
+            (
+                await pcoRequest({
+                    scope: "services",
+                    endpoint: `${arrangementEndpoint}/sections`
+                })
+            )[0]?.attributes.sections || []
+
+        if (!sections.length) {
+            sections = sequence.map((id: any) => ({ label: id, chords: "" }))
+        } else {
+            sections = sections.map(normalizeSongSection)
+        }
     }
 
     if (sequence.length && sections.length) {
@@ -336,7 +394,7 @@ function getOrderedSections(sections: SongSection[], sequence: any[]): SongSecti
 function normalizeSongSection(section: SongSection): SongSection {
     return {
         ...section,
-        lyrics: normalizeLineBreaks(section.lyrics)
+        chords: normalizeLineBreaks(section.chords)
     }
 }
 
@@ -416,24 +474,31 @@ function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[]) {
     const slides: { [key: string]: Slide } = {}
     const layoutSlides: SlideData[] = []
     SECTIONS.forEach((section) => {
-        const slideId = uid()
+        const hasRepetition = section.chords.includes("//")
+        const repetitionCount = hasRepetition ? 2 : 1
+        
+        const cleanedChords = section.chords.replace(/\/\//g, "").trim()
 
-        const items = [
-            {
-                style: itemStyle,
-                lines: section.lyrics.split("\n").map((a: string) => ({ align: "", text: [{ style: "", value: a }] }))
+        for (let rep = 0; rep < repetitionCount; rep++) {
+            const slideId = uid()
+
+            const items = [
+                {
+                    style: itemStyle,
+                    lines: cleanedChords.split("\n").map((a: string) => ({ align: "", text: [{ style: "", value: a }] }))
+                }
+            ]
+
+            slides[slideId] = {
+                group: section.label,
+                globalGroup: section.label.toLowerCase(),
+                color: null,
+                settings: {},
+                notes: "",
+                items
             }
-        ]
-
-        slides[slideId] = {
-            group: section.label,
-            globalGroup: section.label.toLowerCase(),
-            color: null,
-            settings: {},
-            notes: "",
-            items
+            layoutSlides.push({ id: slideId })
         }
-        layoutSlides.push({ id: slideId })
     })
 
     const title = SONG_DATA.attributes.title || ""
@@ -483,7 +548,6 @@ async function getMediaStreamUrl(endpoint: string): Promise<string> {
     return new Promise((resolve) => {
         httpsRequest(PCO_API_URL, apiPath, "POST", headers, {}, (err, result) => {
             if (err) {
-                console.error("Could not get media stream URL:", err)
                 return resolve("")
             }
 

--- a/src/electron/contentProviders/planningCenter/request.ts
+++ b/src/electron/contentProviders/planningCenter/request.ts
@@ -66,17 +66,20 @@ function parseChordChartIntoSections(chordChart: string): SongSection[] {
         const trimmed = line.trim()
 
         // Detect section headers (VERSE, CHORUS, BRIDGE, etc.)
-        const sectionMatch = trimmed.match(/^(VERSO|CORO|PUENTE|INTRO|OUTRO|PRE|ESTRIBILLO|BRIDGE|CHORUS|VERSE|BREAK|INSTRUMENTAL)(\s*\d+)?/i)
+        // Order matters: longer patterns first (PRECORO before PRE, INSTRUMENTAL before INTRO)
+        const sectionMatch = trimmed.match(/^(PRECORO|ESTRIBILLO|INSTRUMENTAL|PUENTE|VERSE|CHORUS|VERSO|CORO|BRIDGE|INTRO|OUTRO|FINAL|PRE|BREAK|TAG|VAMP|INTERLUDE|BREAKDOWN|TURNAROUND|REFRAIN)(\s*\d+)?(?:\s|$)/i)
         if (sectionMatch) {
-            // Save previous section if exists
-            if (currentSectionLabel && currentSectionContent.length) {
-                const content = currentSectionContent.join("\n").trim()
-                sections.push({
-                    label: currentSectionLabel,
-                    lyrics: content
-                })
+            // Save previous section if exists (including sections with only chords)
+            if (currentSectionLabel) {
+                const content = currentSectionContent.map(l => l.trim()).filter(l => l).join("\n").trim()
+                if (content) {
+                    sections.push({
+                        label: currentSectionLabel,
+                        lyrics: content
+                    })
+                }
             }
-            currentSectionLabel = sectionMatch[0]
+            currentSectionLabel = sectionMatch[0].trim()
             currentSectionContent = []
             continue
         }
@@ -87,16 +90,20 @@ function parseChordChartIntoSections(chordChart: string): SongSection[] {
         }
 
         // Keep lyric lines (even if empty)
-        currentSectionContent.push(line)
+        if (trimmed) {
+            currentSectionContent.push(line)
+        }
     }
 
     // Save last section
-    if (currentSectionLabel && currentSectionContent.length) {
-        const content = currentSectionContent.join("\n").trim()
-        sections.push({
-            label: currentSectionLabel,
-            lyrics: content
-        })
+    if (currentSectionLabel) {
+        const content = currentSectionContent.map(l => l.trim()).filter(l => l).join("\n").trim()
+        if (content) {
+            sections.push({
+                label: currentSectionLabel,
+                lyrics: content
+            })
+        }
     }
 
     return sections
@@ -382,6 +389,11 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
         sections = getOrderedSections(sections, sequence)
     }
 
+    // Debug log if we have a sequence but no sections after ordering
+    if (sequence.length && !sections.length) {
+        console.warn(`Planning Center: Song "${songData.attributes?.title}" has sequence but no matching sections. Sequence: ${sequence.join(", ")}`)
+    }
+
     const show = getShow(songData, song, sections)
     const showId = `pcosong_${songData.id}`
 
@@ -393,17 +405,69 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
 
 function getOrderedSections(sections: SongSection[], sequence: any[]): SongSection[] {
     // Reorder sections according to the arrangement sequence
+    // Create a comprehensive section map with multiple keys for flexible matching
     const sectionMap: { [key: string]: SongSection } = {}
+    
     sections.forEach((section) => {
+        const lowerLabel = section.label.toLowerCase()
+        const normalizedLabel = lowerLabel.replace(/\s+/g, " ").trim()
+        const nospaceLabel = normalizedLabel.replace(/\s+/g, "")
+        
+        // Store by all possible variations
         sectionMap[section.label] = section
+        sectionMap[lowerLabel] = section
+        sectionMap[normalizedLabel] = section
+        sectionMap[nospaceLabel] = section
     })
 
     const orderedSections: SongSection[] = []
+    const notFoundLabels: Set<string> = new Set()
+    
     sequence.forEach((label) => {
-        if (sectionMap[label]) {
-            orderedSections.push(sectionMap[label])
+        const normalizedSeqLabel = String(label).toLowerCase().replace(/\s+/g, " ").trim()
+        const nospaceSeqLabel = normalizedSeqLabel.replace(/\s+/g, "")
+        
+        // Try to find matching section with multiple strategies
+        let foundSection = sectionMap[label] ||
+                          sectionMap[normalizedSeqLabel] ||
+                          sectionMap[nospaceSeqLabel]
+        
+        // Try flexible matching for variations like "PRECORO 2" vs "PRECORO2"
+        if (!foundSection) {
+            const matchedKey = Object.keys(sectionMap).find(key => {
+                const keyNormalized = key.toLowerCase().replace(/\s+/g, "")
+                return keyNormalized === nospaceSeqLabel
+            })
+            if (matchedKey) {
+                foundSection = sectionMap[matchedKey]
+            }
+        }
+        
+        // Try partial match (useful for variations)
+        if (!foundSection) {
+            const matchedKey = Object.keys(sectionMap).find(key => {
+                const keyLower = key.toLowerCase()
+                const labelLower = label.toLowerCase()
+                return keyLower.startsWith(labelLower) || 
+                       labelLower.startsWith(keyLower)
+            })
+            if (matchedKey) {
+                foundSection = sectionMap[matchedKey]
+            }
+        }
+
+        if (foundSection) {
+            // Allow same section to appear multiple times in sequence
+            orderedSections.push(foundSection)
+        } else {
+            notFoundLabels.add(label)
         }
     })
+
+    if (notFoundLabels.size > 0) {
+        const availableSections = Array.from(new Set(sections.map(s => s.label))).join(", ")
+        console.warn(`Planning Center: Could not find sections for sequence labels: ${Array.from(notFoundLabels).join(", ")}. Available sections: ${availableSections}`)
+    }
 
     return orderedSections
 }
@@ -493,11 +557,14 @@ function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[]) {
     const layoutSlides: SlideData[] = []
     SECTIONS.forEach((section) => {
         // Check if section has repeat markers (//)
-        const hasRepetition = section.lyrics.includes("//")
+        const hasRepetition = section.lyrics?.includes("//") || false
         const repetitionCount = hasRepetition ? 2 : 1
         
         // Remove repeat markers from display
-        const cleanedLyrics = section.lyrics.replace(/\/\//g, "").trim()
+        const cleanedLyrics = (section.lyrics || "").replace(/\/\//g, "").trim()
+
+        // Skip sections with no lyrics content
+        if (!cleanedLyrics) return
 
         for (let rep = 0; rep < repetitionCount; rep++) {
             const slideId = uid()

--- a/src/electron/contentProviders/planningCenter/request.ts
+++ b/src/electron/contentProviders/planningCenter/request.ts
@@ -26,7 +26,7 @@ type PCORequestData = {
 
 type SongSection = {
     label: string
-    chords: string
+    lyrics: string
     breaks_at?: number
 }
 
@@ -35,15 +35,19 @@ function isLikelyChordLine(line: string): boolean {
     
     const trimmed = line.trim()
     
+    // Pattern to detect musical chords: A-G followed optionally by modifiers
+    // Examples: C, F#m, Dm7, Cmaj7, Bb, etc.
     const chordPattern = /^[A-G][#b]?(?:m|maj|min|add|sus|aug|dim)?[\d]*(?:\s+[A-G][#b]?(?:m|maj|min|add|sus|aug|dim)?[\d]*)*$/
     
     if (chordPattern.test(trimmed)) {
         return true
     }
     
+    // Count the number of chord symbols
     const chordSymbols = (trimmed.match(/[A-G][#b]?/g) || []).length
     const totalChars = trimmed.replace(/\s/g, '').length
     
+    // If high proportion of chord symbols, likely a chord line
     if (chordSymbols > 0 && (chordSymbols / (totalChars / 2)) > 0.5) {
         return true
     }
@@ -61,13 +65,15 @@ function parseChordChartIntoSections(chordChart: string): SongSection[] {
         const line = lines[i]
         const trimmed = line.trim()
 
+        // Detect section headers (VERSE, CHORUS, BRIDGE, etc.)
         const sectionMatch = trimmed.match(/^(VERSO|CORO|PUENTE|INTRO|OUTRO|PRE|ESTRIBILLO|BRIDGE|CHORUS|VERSE|BREAK|INSTRUMENTAL)(\s*\d+)?/i)
         if (sectionMatch) {
+            // Save previous section if exists
             if (currentSectionLabel && currentSectionContent.length) {
                 const content = currentSectionContent.join("\n").trim()
                 sections.push({
                     label: currentSectionLabel,
-                    chords: content
+                    lyrics: content
                 })
             }
             currentSectionLabel = sectionMatch[0]
@@ -75,18 +81,21 @@ function parseChordChartIntoSections(chordChart: string): SongSection[] {
             continue
         }
 
+        // Skip chord lines
         if (isLikelyChordLine(line)) {
             continue
         }
 
+        // Keep lyric lines (even if empty)
         currentSectionContent.push(line)
     }
 
+    // Save last section
     if (currentSectionLabel && currentSectionContent.length) {
         const content = currentSectionContent.join("\n").trim()
         sections.push({
             label: currentSectionLabel,
-            chords: content
+            lyrics: content
         })
     }
 
@@ -140,6 +149,7 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
         return null
     }
 
+    // Build the API path with query parameters if provided
     let apiPath = `/${data.scope || "services"}/v${PCO_API_version}/${data.endpoint}`
     if (data.params) {
         const queryParams = new URLSearchParams(data.params).toString()
@@ -151,6 +161,8 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
     return new Promise((resolve) => {
         httpsRequest(PCO_API_URL, apiPath, "GET", headers, {}, (err, result) => {
             if (err) {
+                // Handle rate limiting
+                // https://developer.planning.center/docs/#/overview/rate-limiting
                 if (err.statusCode === 429) {
                     const retryAfter = parseInt(err?.headers?.["retry-after"], 10) || 2
                     rateLimit(retryAfter)
@@ -164,6 +176,7 @@ export async function pcoRequest(data: PCORequestData, attempt = 0): Promise<any
 
             let resultData = result.data
 
+            // Convert to array for consistent handling
             if (!Array.isArray(resultData)) resultData = [resultData]
 
             resolve(resultData)
@@ -344,9 +357,11 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
 
     let sections: SongSection[] = []
 
+    // Use chord_chart as primary source since it contains repeat markers (//)
     if (song.chord_chart) {
         sections = parseChordChartIntoSections(song.chord_chart)
     } else {
+        // Fallback to sections endpoint if no chord_chart
         sections =
             (
                 await pcoRequest({
@@ -356,12 +371,13 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
             )[0]?.attributes.sections || []
 
         if (!sections.length) {
-            sections = sequence.map((id: any) => ({ label: id, chords: "" }))
+            sections = sequence.map((id: any) => ({ label: id, lyrics: "" }))
         } else {
             sections = sections.map(normalizeSongSection)
         }
     }
 
+    // Order sections according to the arrangement sequence
     if (sequence.length && sections.length) {
         sections = getOrderedSections(sections, sequence)
     }
@@ -376,6 +392,7 @@ async function processSongItem(item: ProjectItem, itemsEndpoint: string) {
 }
 
 function getOrderedSections(sections: SongSection[], sequence: any[]): SongSection[] {
+    // Reorder sections according to the arrangement sequence
     const sectionMap: { [key: string]: SongSection } = {}
     sections.forEach((section) => {
         sectionMap[section.label] = section
@@ -394,11 +411,12 @@ function getOrderedSections(sections: SongSection[], sequence: any[]): SongSecti
 function normalizeSongSection(section: SongSection): SongSection {
     return {
         ...section,
-        chords: normalizeLineBreaks(section.chords)
+        lyrics: normalizeLineBreaks(section.lyrics)
     }
 }
 
 function normalizeLineBreaks(text: string): string {
+    // Normalize different line break formats to consistent \n
     return text.replace(/\n\r/g, "\n").replace(/\r\n/g, "\n").replace(/\r/g, "\n")
 }
 
@@ -474,10 +492,12 @@ function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[]) {
     const slides: { [key: string]: Slide } = {}
     const layoutSlides: SlideData[] = []
     SECTIONS.forEach((section) => {
-        const hasRepetition = section.chords.includes("//")
+        // Check if section has repeat markers (//)
+        const hasRepetition = section.lyrics.includes("//")
         const repetitionCount = hasRepetition ? 2 : 1
         
-        const cleanedChords = section.chords.replace(/\/\//g, "").trim()
+        // Remove repeat markers from display
+        const cleanedLyrics = section.lyrics.replace(/\/\//g, "").trim()
 
         for (let rep = 0; rep < repetitionCount; rep++) {
             const slideId = uid()
@@ -485,7 +505,7 @@ function getShow(SONG_DATA: any, SONG: any, SECTIONS: any[]) {
             const items = [
                 {
                     style: itemStyle,
-                    lines: cleanedChords.split("\n").map((a: string) => ({ align: "", text: [{ style: "", value: a }] }))
+                    lines: cleanedLyrics.split("\n").map((a: string) => ({ align: "", text: [{ style: "", value: a }] }))
                 }
             ]
 
@@ -548,6 +568,7 @@ async function getMediaStreamUrl(endpoint: string): Promise<string> {
     return new Promise((resolve) => {
         httpsRequest(PCO_API_URL, apiPath, "POST", headers, {}, (err, result) => {
             if (err) {
+                console.error("Could not get media stream URL:", err)
                 return resolve("")
             }
 


### PR DESCRIPTION
Songs now pull lyrics directly from Planning Center's chord charts instead of the lyrics section. This preserves the repeat markers (//) that were missing before. The system automatically filters out the chord symbols and keeps only the text clean.

When a section has repeat markers (//), FreeShow automatically creates two identical slides for that section. This lets presenters switch between repeats during live performances without manual editing.