### PR TITLE
Ensure password input is masked when prompting for admin profile access

### DIFF
--- a/src/frontend/components/settings/tabs/Profiles.svelte
+++ b/src/frontend/components/settings/tabs/Profiles.svelte
@@ -168,7 +168,7 @@
     async function setCurrentAsActive() {
         // require password if setting admin profile (and password exists)
         if (profileId === "" && hasAdminPass) {
-            const pwd = await promptCustom(translateText("remote.password"))
+            const pwd = await promptCustom(translateText("remote.password"), "password")
             const adminPassword = $profiles.admin?.password || ""
             if (!checkPassword(pwd, adminPassword)) {
                 newToast("remote.wrong_password")


### PR DESCRIPTION
Related to https://github.com/ChurchApps/FreeShow/issues/2974

Admin password was also visible when changing from the profile settings tab