### PR TITLE
Allow access to locked slides when removing next timer layout

### DIFF
--- a/src/frontend/components/slide/Icons.svelte
+++ b/src/frontend/components/slide/Icons.svelte
@@ -34,13 +34,13 @@
 
     $: currentShow = $shows[$activeShow?.id || ""] || {}
 
-    function hasAccess() {
+    function hasAccess(allowLockedSlide = false) {
         if (currentShow.locked) {
             newToast("show.locked")
             return false
         }
 
-        if (slide?.locked) {
+        if (slide?.locked && !allowLockedSlide) {
             newToast("output.state_locked")
             return false
         }
@@ -56,7 +56,7 @@
     }
 
     function removeLayout(key: string) {
-        if (!hasAccess()) return
+        if (!hasAccess(key === "nextTimer")) return
 
         history({ id: "SHOW_LAYOUT", newData: { key, indexes: [index] } })
     }


### PR DESCRIPTION
We have a slide that is allways locked and we add more slide to add images, we add next slide timer to all of the slides, but if any sunday there are no images extra to add the next slide timer can not be deleted from the locked slide, so project it will move to next section when next timer ends