### PR TITLE
Stabilize Remote Media Slides Behavior

### DIFF
--- a/src/frontend/utils/remoteTalk.ts
+++ b/src/frontend/utils/remoteTalk.ts
@@ -5,7 +5,7 @@ import type { ClientMessage } from "../../types/Socket"
 import { AudioPlayer } from "../audio/audioPlayer"
 import { loadJsonBible } from "../components/drawer/bible/scripture"
 import { clone, keysToID, removeDeleted } from "../components/helpers/array"
-import { getBase64Path, getThumbnailPath, mediaSize } from "../components/helpers/media"
+import { getThumbnailPath, mediaSize } from "../components/helpers/media"
 import { getAllNormalOutputs, getFirstActiveOutput, setOutput } from "../components/helpers/output"
 import { loadShows } from "../components/helpers/setShow"
 import { getLayoutRef } from "../components/helpers/show"
@@ -110,13 +110,8 @@ export const receiveREMOTE: any = {
         loadingShow = showID
         await loadShows([showID])
 
-        // send before any backgrounds has loaded
+        // Send once to avoid duplicate renders and thumbnail request bursts on remote clients.
         msg.data = clone({ ...(await convertBackgrounds(get(showsCache)[showID], true)), id: showID })
-        if (loadingShow !== showID) return
-        window.api.send(REMOTE, msg)
-
-        msg.data = clone({ ...(await convertBackgrounds(get(showsCache)[showID])), id: showID })
-        // send(REMOTE, ["MEDIA"], { media: msg.data.media })
 
         if (loadingShow !== showID) return
 
@@ -407,31 +402,29 @@ export async function convertBackgrounds(show: Show, noLoad = false, init = fals
     if (!show?.media) return {}
 
     show = clone(show)
-    const mediaIds: string[] = []
+    const mediaIds = new Set<string>()
     show.layouts[show.settings?.activeLayout]?.slides.forEach((a) => {
-        if (a.background) mediaIds.push(a.background)
+        if (a.background) mediaIds.add(a.background)
         Object.values(a.children || {}).forEach((child) => {
-            if (child.background) mediaIds.push(child.background)
+            if (child.background) mediaIds.add(child.background)
         })
     })
 
-    await Promise.all(
-        mediaIds.map(async (id) => {
-            let path = show.media[id]?.path || show.media[id]?.id || ""
-            if (!path) return
+    ;[...mediaIds].forEach((id) => {
+        let path = show.media[id]?.path || show.media[id]?.id || ""
+        if (!path) return
 
-            if (noLoad) {
-                show.media[id].path = getThumbnailPath(path, mediaSize.slideSize)
-                return
-            }
+        if (noLoad) {
+            show.media[id].path = getThumbnailPath(path, mediaSize.slideSize)
+            return
+        }
 
-            const remoteConnections = Object.keys(get(connections).REMOTE || {})?.length || 0
-            if (!init && remoteConnections === 0) return
+        const remoteConnections = Object.keys(get(connections).REMOTE || {})?.length || 0
+        if (!init && remoteConnections === 0) return
 
-            const base64Path: string = await getBase64Path(path, mediaSize.slideSize)
-            if (base64Path) show.media[id].path = base64Path
-        })
-    )
+        // Keep paths as thumbnails for remote and let remote request them lazily.
+        show.media[id].path = getThumbnailPath(path, mediaSize.slideSize)
+    })
 
     return show
 }

--- a/src/server/remote/components/show/ShowSlide.svelte
+++ b/src/server/remote/components/show/ShowSlide.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { getGroupName } from "../../../common/util/show"
-    import { send } from "../../util/socket"
     import { activeShow, mediaCache } from "../../util/stores"
     import Textbox from "./Textbox.svelte"
     import Zoomed from "./Zoomed.svelte"
@@ -13,6 +12,7 @@
     export let columns: number = 1
     export let active: boolean = false
     export let resolution: any
+    export let renderItems: boolean = true
 
     let ratio = 0
 
@@ -23,9 +23,10 @@
 
     $: name = $activeShow ? getGroupName({ show: $activeShow, showId: $activeShow.id || "" }, layoutSlide.id, slide.group, index) || slide.group || "" : ""
 
-    $: slide?.items?.forEach((item: any) => {
-        if (item.type === "media" && item.src && !$mediaCache[item.src]) send("API:get_thumbnail", { path: item.src })
-    })
+    $: backgroundPath = media?.[layoutSlide.background]?.path || ""
+    $: backgroundThumb = backgroundPath ? $mediaCache[backgroundPath] : ""
+    $: canRenderPath = backgroundPath.startsWith("data:") || backgroundPath.startsWith("http://") || backgroundPath.startsWith("https://") || backgroundPath.startsWith("blob:")
+    $: isSlideReady = !backgroundPath || !!backgroundThumb || canRenderPath
 </script>
 
 <!-- TODO: disabled -->
@@ -35,18 +36,32 @@
 class:left={overIndex === index && (!selected.length || index <= selected[0])} -->
 <div class="main" style="width: {100 / columns}%">
     <div class="slide context #slide" class:disabled={layoutSlide.disabled} class:active style="background-color: {color};" tabindex={0} data-index={index} on:click>
-        <Zoomed resolution={newResolution} background={slide.settings?.color || (slide.items.length ? "black" : "transparent")} bind:ratio>
-            <!-- class:ghost={!background} -->
-            <div class="background" style="zoom: {1 / ratio}">
-                {#if media[layoutSlide.background]?.path && !media[layoutSlide.background].path.includes("freeshow-cache") && !media[layoutSlide.background].path.includes("media-cache")}
-                    <img src={media[layoutSlide.background].path} />
+        {#if isSlideReady && renderItems}
+            <Zoomed resolution={newResolution} background={slide.settings?.color || (slide.items.length ? "black" : "transparent")} bind:ratio>
+                <!-- class:ghost={!background} -->
+                <div class="background" style="zoom: {1 / ratio}">
+                    {#if backgroundThumb}
+                        <img src={backgroundThumb} alt="" loading="lazy" decoding="async" />
+                    {:else if canRenderPath}
+                        <img src={backgroundPath} alt="" loading="lazy" decoding="async" />
+                    {/if}
+                </div>
+                <!-- TODO: check if showid exists in shows -->
+                {#each slide.items as item}
+                    <Textbox {item} />
+                {/each}
+            </Zoomed>
+        {:else if isSlideReady}
+            <div class="light-background">
+                {#if backgroundThumb}
+                    <img src={backgroundThumb} alt="" loading="lazy" decoding="async" />
+                {:else if canRenderPath}
+                    <img src={backgroundPath} alt="" loading="lazy" decoding="async" />
                 {/if}
             </div>
-            <!-- TODO: check if showid exists in shows -->
-            {#each slide.items as item}
-                <Textbox {item} />
-            {/each}
-        </Zoomed>
+        {:else}
+            <div class="thumb-placeholder"></div>
+        {/if}
         <!-- TODO: BG: white, color: black -->
         <!-- style="width: {newResolution.width * zoom}px;" -->
 
@@ -98,6 +113,37 @@ class:left={overIndex === index && (!selected.length || index <= selected[0])} -
         width: 100%;
         height: 100%;
         object-fit: contain;
+    }
+
+    .light-background {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        position: relative;
+        background: black;
+        overflow: hidden;
+    }
+
+    .light-background :global(img) {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+    }
+
+    .thumb-placeholder {
+        width: 100%;
+        aspect-ratio: 16 / 9;
+        background: linear-gradient(90deg, var(--primary-darkest), var(--primary-darker), var(--primary-darkest));
+        background-size: 200% 100%;
+        animation: thumb-loading 1.1s linear infinite;
+    }
+
+    @keyframes thumb-loading {
+        0% {
+            background-position: 200% 0;
+        }
+        100% {
+            background-position: -200% 0;
+        }
     }
 
     .label {

--- a/src/server/remote/components/show/ShowSlide.svelte
+++ b/src/server/remote/components/show/ShowSlide.svelte
@@ -26,7 +26,7 @@
     $: backgroundPath = media?.[layoutSlide.background]?.path || ""
     $: backgroundThumb = backgroundPath ? $mediaCache[backgroundPath] : ""
     $: canRenderPath = backgroundPath.startsWith("data:") || backgroundPath.startsWith("http://") || backgroundPath.startsWith("https://") || backgroundPath.startsWith("blob:")
-    $: isSlideReady = !backgroundPath || !!backgroundThumb || canRenderPath
+    $: backgroundSrc = backgroundThumb || (canRenderPath ? backgroundPath : backgroundPath || "")
 </script>
 
 <!-- TODO: disabled -->
@@ -36,14 +36,12 @@
 class:left={overIndex === index && (!selected.length || index <= selected[0])} -->
 <div class="main" style="width: {100 / columns}%">
     <div class="slide context #slide" class:disabled={layoutSlide.disabled} class:active style="background-color: {color};" tabindex={0} data-index={index} on:click>
-        {#if isSlideReady && renderItems}
+        {#if renderItems}
             <Zoomed resolution={newResolution} background={slide.settings?.color || (slide.items.length ? "black" : "transparent")} bind:ratio>
                 <!-- class:ghost={!background} -->
                 <div class="background" style="zoom: {1 / ratio}">
-                    {#if backgroundThumb}
-                        <img src={backgroundThumb} alt="" loading="lazy" decoding="async" />
-                    {:else if canRenderPath}
-                        <img src={backgroundPath} alt="" loading="lazy" decoding="async" />
+                    {#if backgroundPath}
+                        <img src={backgroundSrc} alt="" loading="lazy" decoding="async" />
                     {/if}
                 </div>
                 <!-- TODO: check if showid exists in shows -->
@@ -51,16 +49,12 @@ class:left={overIndex === index && (!selected.length || index <= selected[0])} -
                     <Textbox {item} />
                 {/each}
             </Zoomed>
-        {:else if isSlideReady}
+        {:else}
             <div class="light-background">
-                {#if backgroundThumb}
-                    <img src={backgroundThumb} alt="" loading="lazy" decoding="async" />
-                {:else if canRenderPath}
-                    <img src={backgroundPath} alt="" loading="lazy" decoding="async" />
+                {#if backgroundPath}
+                    <img src={backgroundSrc} alt="" loading="lazy" decoding="async" />
                 {/if}
             </div>
-        {:else}
-            <div class="thumb-placeholder"></div>
         {/if}
         <!-- TODO: BG: white, color: black -->
         <!-- style="width: {newResolution.width * zoom}px;" -->
@@ -127,23 +121,6 @@ class:left={overIndex === index && (!selected.length || index <= selected[0])} -
         width: 100%;
         height: 100%;
         object-fit: contain;
-    }
-
-    .thumb-placeholder {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        background: linear-gradient(90deg, var(--primary-darkest), var(--primary-darker), var(--primary-darkest));
-        background-size: 200% 100%;
-        animation: thumb-loading 1.1s linear infinite;
-    }
-
-    @keyframes thumb-loading {
-        0% {
-            background-position: 200% 0;
-        }
-        100% {
-            background-position: -200% 0;
-        }
     }
 
     .label {

--- a/src/server/remote/components/show/ShowSlide.svelte
+++ b/src/server/remote/components/show/ShowSlide.svelte
@@ -12,7 +12,6 @@
     export let columns: number = 1
     export let active: boolean = false
     export let resolution: any
-    export let renderItems: boolean = true
 
     let ratio = 0
 
@@ -36,26 +35,18 @@
 class:left={overIndex === index && (!selected.length || index <= selected[0])} -->
 <div class="main" style="width: {100 / columns}%">
     <div class="slide context #slide" class:disabled={layoutSlide.disabled} class:active style="background-color: {color};" tabindex={0} data-index={index} on:click>
-        {#if renderItems}
-            <Zoomed resolution={newResolution} background={slide.settings?.color || (slide.items.length ? "black" : "transparent")} bind:ratio>
-                <!-- class:ghost={!background} -->
-                <div class="background" style="zoom: {1 / ratio}">
-                    {#if backgroundPath}
-                        <img src={backgroundSrc} alt="" loading="lazy" decoding="async" />
-                    {/if}
-                </div>
-                <!-- TODO: check if showid exists in shows -->
-                {#each slide.items as item}
-                    <Textbox {item} />
-                {/each}
-            </Zoomed>
-        {:else}
-            <div class="light-background">
+        <Zoomed resolution={newResolution} background={slide.settings?.color || (slide.items.length ? "black" : "transparent")} bind:ratio>
+            <!-- class:ghost={!background} -->
+            <div class="background" style="zoom: {1 / ratio}">
                 {#if backgroundPath}
                     <img src={backgroundSrc} alt="" loading="lazy" decoding="async" />
                 {/if}
             </div>
-        {/if}
+            <!-- TODO: check if showid exists in shows -->
+            {#each slide.items as item}
+                <Textbox {item} />
+            {/each}
+        </Zoomed>
         <!-- TODO: BG: white, color: black -->
         <!-- style="width: {newResolution.width * zoom}px;" -->
 
@@ -104,20 +95,6 @@ class:left={overIndex === index && (!selected.length || index <= selected[0])} -
     opacity: 0.4;
   } */
     .background :global(img) {
-        width: 100%;
-        height: 100%;
-        object-fit: contain;
-    }
-
-    .light-background {
-        width: 100%;
-        aspect-ratio: 16 / 9;
-        position: relative;
-        background: black;
-        overflow: hidden;
-    }
-
-    .light-background :global(img) {
         width: 100%;
         height: 100%;
         object-fit: contain;

--- a/src/server/remote/components/show/Slide.svelte
+++ b/src/server/remote/components/show/Slide.svelte
@@ -5,7 +5,8 @@
     import Zoomed from "./Zoomed.svelte"
     import { GetLayout } from "../../util/output"
     import { getStyleResolution } from "../../../common/util/getStyleResolution"
-    import { outLayout, outShow, styleRes } from "../../util/stores"
+    import { send } from "../../util/socket"
+    import { mediaCache, outLayout, outShow, styleRes } from "../../util/stores"
 
     export let outSlide: number
     export let preview: boolean = false
@@ -20,6 +21,13 @@
     $: layout = GetLayout($outShow, $outLayout)[outSlide]
 
     $: showSlide = $outShow?.slides?.[layout?.id] || null
+    $: backgroundPath = $outShow?.media?.[layout?.background || ""]?.path || ""
+    $: backgroundThumb = backgroundPath ? $mediaCache[backgroundPath] : ""
+    $: canRenderPath = backgroundPath.startsWith("data:") || backgroundPath.startsWith("http://") || backgroundPath.startsWith("https://") || backgroundPath.startsWith("blob:")
+    $: backgroundSrc = backgroundThumb || (canRenderPath ? backgroundPath : "")
+    $: if (backgroundPath && !canRenderPath && !$mediaCache[backgroundPath]) {
+        send("API:get_thumbnail", { path: backgroundPath })
+    }
 
     $: isCustomRes = resolution.width !== 1920 || resolution.height !== 1080
     // WIP get layout resolution
@@ -33,8 +41,8 @@
     <MediaOutput {...$outBackground} {transition} bind:video bind:videoData />
   {/if} -->
         <div class="background" style="zoom: {1 / ratio}">
-            {#if $outShow?.media?.[layout?.background || ""]}
-                <img src={$outShow.media[layout.background || ""].path} />
+            {#if backgroundSrc}
+                <img src={backgroundSrc} alt="" loading="lazy" decoding="async" />
             {/if}
         </div>
         {#if $outShow}

--- a/src/server/remote/components/show/Slides.svelte
+++ b/src/server/remote/components/show/Slides.svelte
@@ -86,10 +86,8 @@
             e.preventDefault()
             let dist = Math.hypot(e.touches[0].pageX - e.touches[1].pageX, e.touches[0].pageY - e.touches[1].pageY)
 
-            let newColumns = 1
             scaled = initialDistance / margin - dist / margin
-            if (scaled < 0) newColumns = initialColumns + scaled
-            else newColumns = initialColumns + scaled
+            const newColumns = initialColumns + scaled
 
             columns = Math.min(4, Math.max(1, Math.floor(newColumns)))
         }
@@ -105,12 +103,24 @@
     // Keep thumbnail requests slow, but enqueue all slides immediately on show open.
     const THUMB_REQUEST_DELAY = 180
     let lastShowId = ""
+    let currentShowId = ""
+    let allSlides: Array<{ slide: any; index: number; backgroundPath: string }> = []
     const queuedThumbs = new Set<string>()
     const thumbQueue: string[] = []
     let drainingThumbs = false
+    let destroyed = false
+
+    function resetThumbnailQueue() {
+        thumbQueue.length = 0
+        queuedThumbs.clear()
+    }
 
     function isDirectPath(path: string) {
-        return path.startsWith("data:") || path.startsWith("http://") || path.startsWith("https://") || path.startsWith("blob:")
+        return /^(data:|https?:\/\/|blob:)/.test(path)
+    }
+
+    function sleep(ms: number) {
+        return new Promise<void>((resolve) => setTimeout(resolve, ms))
     }
 
     function queueThumbnail(path: string) {
@@ -124,21 +134,22 @@
         if (drainingThumbs) return
         drainingThumbs = true
 
-        while (thumbQueue.length) {
-            const path = thumbQueue.shift()
-            if (!path) continue
-            send("API:get_thumbnail", { path })
-            await new Promise((resolve) => setTimeout(resolve, THUMB_REQUEST_DELAY))
+        try {
+            while (thumbQueue.length && !destroyed) {
+                const path = thumbQueue.shift()
+                if (!path) continue
+                send("API:get_thumbnail", { path })
+                await sleep(THUMB_REQUEST_DELAY)
+            }
+        } finally {
+            drainingThumbs = false
         }
-
-        drainingThumbs = false
     }
 
     $: currentShowId = $activeShow?.id || ""
     $: if (currentShowId !== lastShowId) {
         lastShowId = currentShowId
-        thumbQueue.length = 0
-        queuedThumbs.clear()
+        resetThumbnailQueue()
     }
 
     $: allSlides = layoutSlides.map((slide, index) => {
@@ -152,8 +163,8 @@
     })
 
     onDestroy(() => {
-        thumbQueue.length = 0
-        queuedThumbs.clear()
+        destroyed = true
+        resetThumbnailQueue()
         if (pendingScrollTimer) clearTimeout(pendingScrollTimer)
     })
 </script>
@@ -171,7 +182,6 @@
                     index={entry.index}
                     color={entry.slide.color}
                     active={isActive}
-                    renderItems={true}
                     {columns}
                     on:click={() => {
                         // if (!$outLocked && !e.ctrlKey) {

--- a/src/server/remote/components/show/Slides.svelte
+++ b/src/server/remote/components/show/Slides.svelte
@@ -1,10 +1,11 @@
 <script lang="ts">
-    import { createEventDispatcher, onMount } from "svelte"
+    import { createEventDispatcher, onDestroy, onMount } from "svelte"
     import type { Resolution } from "../../../../types/Settings"
     import Center from "../../../common/components/Center.svelte"
     import { translate } from "../../util/helpers"
     import { GetLayout } from "../../util/output"
-    import { activeShow, outShow, styleRes } from "../../util/stores"
+    import { send } from "../../util/socket"
+    import { activeShow, mediaCache, outShow, styleRes } from "../../util/stores"
     import Slide from "./ShowSlide.svelte"
 
     export let outSlide: number | null
@@ -20,13 +21,43 @@
     // auto scroll
     export let scrollElem: HTMLElement | undefined
     let lastScrollId = "-1"
+    let pendingScrollIndex: number | null = null
+    let pendingScrollTries = 0
+    let pendingScrollTimer: ReturnType<typeof setTimeout> | null = null
+
+    function runAutoScroll() {
+        if (!scrollElem || pendingScrollIndex === null) return
+
+        const slideElem = scrollElem.querySelector(`.grid [data-index=\"${pendingScrollIndex}\"]`) as HTMLElement | null
+        if (!slideElem) {
+            if (pendingScrollTries < 80) {
+                pendingScrollTries++
+                if (pendingScrollTimer) clearTimeout(pendingScrollTimer)
+                pendingScrollTimer = setTimeout(runAutoScroll, 80)
+            }
+            return
+        }
+
+        const slideRect = slideElem.getBoundingClientRect()
+        const containerRect = scrollElem.getBoundingClientRect()
+        const offset = slideRect.top - containerRect.top + scrollElem.scrollTop - 54
+        scrollElem.scrollTo(0, offset)
+        pendingScrollIndex = null
+        pendingScrollTries = 0
+        if (pendingScrollTimer) {
+            clearTimeout(pendingScrollTimer)
+            pendingScrollTimer = null
+        }
+    }
+
     $: {
-        if (scrollElem?.querySelector(".grid") && outSlide !== null && $outShow?.id === $activeShow?.id) {
-            let index = Math.max(0, outSlide)
+        if (outSlide !== null && $outShow?.id === $activeShow?.id) {
+            const index = Math.max(0, outSlide)
             if (($outShow?.id || "") + index !== lastScrollId) {
                 lastScrollId = ($outShow?.id || "") + index
-                let offset = (scrollElem.querySelector(".grid")?.children[index] as HTMLElement)?.offsetTop - scrollElem.offsetTop - 4 - 50
-                scrollElem.scrollTo(0, offset)
+                pendingScrollIndex = index
+                pendingScrollTries = 0
+                runAutoScroll()
             }
         }
     }
@@ -70,29 +101,95 @@
     onMount(() => {
         loadingStarted = true
     })
+
+    // Keep thumbnail requests slow, but enqueue all slides immediately on show open.
+    const THUMB_REQUEST_DELAY = 180
+    let lastShowId = ""
+    const queuedThumbs = new Set<string>()
+    const thumbQueue: string[] = []
+    let drainingThumbs = false
+
+    function isDirectPath(path: string) {
+        return path.startsWith("data:") || path.startsWith("http://") || path.startsWith("https://") || path.startsWith("blob:")
+    }
+
+    function queueThumbnail(path: string) {
+        if (!path || queuedThumbs.has(path)) return
+        queuedThumbs.add(path)
+        thumbQueue.push(path)
+        if (!drainingThumbs) void drainThumbnailQueue()
+    }
+
+    async function drainThumbnailQueue() {
+        if (drainingThumbs) return
+        drainingThumbs = true
+
+        while (thumbQueue.length) {
+            const path = thumbQueue.shift()
+            if (!path) continue
+            send("API:get_thumbnail", { path })
+            await new Promise((resolve) => setTimeout(resolve, THUMB_REQUEST_DELAY))
+        }
+
+        drainingThumbs = false
+    }
+
+    $: currentShowId = $activeShow?.id || ""
+    $: if (currentShowId !== lastShowId) {
+        lastShowId = currentShowId
+        thumbQueue.length = 0
+        queuedThumbs.clear()
+    }
+
+    $: allSlides = layoutSlides.map((slide, index) => {
+        const backgroundPath = $activeShow?.media?.[slide.background || ""]?.path || ""
+        return { slide, index, backgroundPath }
+    })
+
+    $: allSlides.forEach(({ backgroundPath }) => {
+        if (!backgroundPath || isDirectPath(backgroundPath) || $mediaCache[backgroundPath]) return
+        queueThumbnail(backgroundPath)
+    })
+
+    $: readySlides = allSlides.filter(({ backgroundPath }) => {
+        if (!backgroundPath) return true
+        return isDirectPath(backgroundPath) || !!$mediaCache[backgroundPath]
+    })
+
+    onDestroy(() => {
+        thumbQueue.length = 0
+        queuedThumbs.clear()
+        if (pendingScrollTimer) clearTimeout(pendingScrollTimer)
+    })
 </script>
 
 <div class="grid" on:touchstart={touchstart} on:touchmove={touchmove} on:touchend={touchend}>
     {#if layoutSlides.length}
         {#if layoutSlides.length < 10 || loadingStarted}
-            {#each layoutSlides as slide, i (`${$activeShow?.id || "show"}-${slide.id || "slide"}-${i}`)}
+            {#each readySlides as entry (`${$activeShow?.id || "show"}-${entry.slide.id || "slide"}-${entry.index}`)}
+                {@const isActive = outSlide === entry.index && $outShow?.id === $activeShow?.id}
+                {@const useLightMode = layoutSlides.length > 12 && !isActive}
                 <Slide
                     {resolution}
                     media={$activeShow?.media}
-                    layoutSlide={slide}
-                    slide={$activeShow?.slides[slide.id]}
-                    index={i}
-                    color={slide.color}
-                    active={outSlide === i && $outShow?.id === $activeShow?.id}
+                    layoutSlide={entry.slide}
+                    slide={$activeShow?.slides[entry.slide.id]}
+                    index={entry.index}
+                    color={entry.slide.color}
+                    active={isActive}
+                    renderItems={!useLightMode}
                     {columns}
                     on:click={() => {
                         // if (!$outLocked && !e.ctrlKey) {
                         //   outSlide.set({ id, index: i })
                         // }
-                        click(i)
+                        click(entry.index)
                     }}
                 />
             {/each}
+            {#if readySlides.length < allSlides.length}
+                <Center faded>{translate("remote.loading", $dictionary)}</Center>
+            {/if}
         {:else}
             <Center faded>{translate("remote.loading", $dictionary)}</Center>
         {/if}

--- a/src/server/remote/components/show/Slides.svelte
+++ b/src/server/remote/components/show/Slides.svelte
@@ -151,11 +151,6 @@
         queueThumbnail(backgroundPath)
     })
 
-    $: readySlides = allSlides.filter(({ backgroundPath }) => {
-        if (!backgroundPath) return true
-        return isDirectPath(backgroundPath) || !!$mediaCache[backgroundPath]
-    })
-
     onDestroy(() => {
         thumbQueue.length = 0
         queuedThumbs.clear()
@@ -166,9 +161,8 @@
 <div class="grid" on:touchstart={touchstart} on:touchmove={touchmove} on:touchend={touchend}>
     {#if layoutSlides.length}
         {#if layoutSlides.length < 10 || loadingStarted}
-            {#each readySlides as entry (`${$activeShow?.id || "show"}-${entry.slide.id || "slide"}-${entry.index}`)}
+            {#each allSlides as entry (`${$activeShow?.id || "show"}-${entry.slide.id || "slide"}-${entry.index}`)}
                 {@const isActive = outSlide === entry.index && $outShow?.id === $activeShow?.id}
-                {@const useLightMode = layoutSlides.length > 12 && !isActive}
                 <Slide
                     {resolution}
                     media={$activeShow?.media}
@@ -177,7 +171,7 @@
                     index={entry.index}
                     color={entry.slide.color}
                     active={isActive}
-                    renderItems={!useLightMode}
+                    renderItems={true}
                     {columns}
                     on:click={() => {
                         // if (!$outLocked && !e.ctrlKey) {
@@ -187,9 +181,6 @@
                     }}
                 />
             {/each}
-            {#if readySlides.length < allSlides.length}
-                <Center faded>{translate("remote.loading", $dictionary)}</Center>
-            {/if}
         {:else}
             <Center faded>{translate("remote.loading", $dictionary)}</Center>
         {/if}


### PR DESCRIPTION
## Main changes

- **Removed heavy background base64 conversion for Remote shows**
  - Remote no longer bulk-converts slide backgrounds to base64.
  - Backgrounds are now handled through thumbnail paths, which reduces memory pressure.

- **Removed duplicate `SHOW` payload burst**
  - Remote now sends the show payload only once (instead of a quick + full double-send pattern).
  - This reduces unnecessary re-renders and request storms.

- **Added controlled thumbnail queueing for slide backgrounds**
  - Thumbnail requests (`API:get_thumbnail`) are now queued and rate-limited instead of firing in large uncontrolled bursts.
  - All slide thumbnails are queued when opening the show, with throttled processing.

- **Synced slide creation with thumbnail readiness**
  - Slides are rendered in the list only when their background thumbnail (or another directly renderable source) is ready.
  - This avoids creating many empty slide cards first and filling them later.

- **Reduced rendering cost for large slide lists**
  - For large shows, non-active slide cards use a lightweight rendering path (background-focused), while the active slide keeps full rendering.
  - This lowers memory and paint overhead during heavy scrolling.