### PR TITLE
Normalize route.bible branding for scripture actions

### DIFF
--- a/src/frontend/components/context/contextMenus.ts
+++ b/src/frontend/components/context/contextMenus.ts
@@ -188,7 +188,7 @@ export const contextMenuItems: { [key: string]: ContextMenuItem } = {
     // TEMPLATES
     template_actions: { label: "tabs.actions", icon: "actions", iconColor: "#d497ff" },
     // SCRIPTUES
-    route_bible: { label: "main.open: Route Bible", icon: "launch" },
+    route_bible: { label: "main.open: route.bible", icon: "launch" },
     // STAGE
     move_connections: { label: "context.move_connections", icon: "up" },
     // SETTINGS


### PR DESCRIPTION
## Summary
- normalizes the remaining user-visible `Route Bible` branding introduced by #3018 to `route.bible`
- keeps the existing route.bible URL generation and action wiring unchanged
- scopes the follow-up to branding copy only

## Details
- updates the scripture context-menu label from `Route Bible` to `route.bible`
- leaves helpers such as `buildRouteBibleUrl` and all `https://route.bible/...` URLs untouched
- avoids any behavior or API changes beyond visible copy

## Validation
- `npx prettier --config config/formatting/.prettierrc.yaml --check src/frontend/components/context/contextMenus.ts`

## Post-Deploy Monitoring & Validation
No additional operational monitoring required because this follow-up only changes a user-visible menu label.
