### PR TITLE
Fix delete action not removing groups in shortcuts

### DIFF
--- a/src/frontend/utils/shortcuts.ts
+++ b/src/frontend/utils/shortcuts.ts
@@ -122,7 +122,7 @@ const keys = {
             if (lastUsedProject) openProject(lastUsedProject.id)
         }
     },
-    Delete: () => (get(contextActive) ? null : deleteAction(get(selected), "remove")),
+    Delete: () => (get(contextActive) ? null : deleteAction(get(selected))),
     Backspace: () => keys.Delete(),
     // give time so it don't clear slide
     F2: () => (get(focusMode) ? null : setTimeout(() => menuClick("rename", true, null, null, null, get(selected)))),


### PR DESCRIPTION
small fix where groups are not being deleted when deleting slides with the del key