### PR TITLE
fix: enable early warning for clock and event timers

### DIFF
--- a/src/frontend/components/slide/views/Timer.svelte
+++ b/src/frontend/components/slide/views/Timer.svelte
@@ -70,7 +70,10 @@
 
     function getTimerOverflow(time: number, offset = 0) {
         if (currentTime < 0) return true
-        if (timer.type !== "counter") return false
+        if (timer.type !== "counter") {
+            // For clock/event timers, check if remaining time is within offset
+            return time <= offset
+        }
 
         let start = timer.start || 0
         let end = timer.end || 0


### PR DESCRIPTION
## Bug
[#3032](https://github.com/ChurchApps/FreeShow/issues/3032) — Early warning doesn't work with Towards-A-Time timers.

## Fix
The `getTimerOverflow` function in `Timer.svelte` was returning `false` immediately for non-counter timers (line 63):

```typescript
if (timer.type !== "counter") return false
```

This prevented early warning from ever triggering for clock and event timers.

For clock/event timers, `currentTime` represents seconds remaining until the target time. Early warning should trigger when this remaining time falls within the `warnOffset` threshold. The fix adds proper handling for these timer types by checking if the remaining time is less than or equal to the offset.

## Testing
- Create a clock timer (Towards-A-Time)
- Set early warning threshold (e.g., 30 seconds)
- Set warning color
- Timer should now display warning color when within the threshold

Happy to address any feedback.

Greetings, saschabuehrle