### PR TITLE
Add libproxy1v5 dependency to snapcraft.yaml

### DIFF
--- a/config/building/snapcraft.yaml
+++ b/config/building/snapcraft.yaml
@@ -53,6 +53,7 @@ parts:
             - libnode109
             - libglu1-mesa
             - libltc11
+            - libproxy1v5
 apps:
     freeshow:
         command: command.sh


### PR DESCRIPTION
Runtime dependency, freeshow whines about it on start.