### PR TITLE
Fix: make hostname/IP setting per connection instead of global

### DIFF
--- a/src/frontend/components/main/popups/Connect.svelte
+++ b/src/frontend/components/main/popups/Connect.svelte
@@ -18,7 +18,7 @@
     let id: keyof typeof defaultPorts = "stage"
     let ip = "localhost"
 
-    $: useHostname = $special.connectionHostname
+    $: useHostname = getUseHostname(id)
 
     onMount(() => {
         id = $popupData.id
@@ -98,9 +98,16 @@
         sendMain(Main.SERVER_DATA, $serverData)
     }
 
-    function updateSpecial(key: string, value: any) {
-        special.update((a) => {
-            a[key] = value
+    function getUseHostname(connectionId: string) {
+        const perConnectionValue = $serverData?.[connectionId]?.useHostname
+        if (typeof perConnectionValue === "boolean") return perConnectionValue
+        return !!$special.connectionHostname
+    }
+
+    function updateUseHostname(value: boolean) {
+        serverData.update((a) => {
+            if (!a[id]) a[id] = {}
+            a[id].useHostname = value
             return a
         })
     }
@@ -131,7 +138,7 @@
         <hr />
 
         <MaterialNumberInput label="settings.max_connections" value={$maxConnections} max={100} on:change={(e) => maxConnections.set(e.detail)} />
-        <MaterialToggleSwitch label="settings.use_hostname" checked={$special.connectionHostname} defaultValue={false} on:change={(e) => updateSpecial("connectionHostname", e.detail)} />
+        <MaterialToggleSwitch label="settings.use_hostname" checked={useHostname} defaultValue={false} on:change={(e) => updateUseHostname(e.detail)} />
     {/if}
 {:else}
     <div on:mouseup={mouseup}>

--- a/src/frontend/utils/updateSettings.ts
+++ b/src/frontend/utils/updateSettings.ts
@@ -112,6 +112,8 @@ export function updateSettings(data: any) {
         else console.info("RECEIVED UNKNOWN SETTINGS KEY:", key)
     })
 
+    migrateLegacyConnectionHostnameSetting()
+
     if (!isMainWindow()) return
 
     // output
@@ -158,6 +160,23 @@ export function updateSettings(data: any) {
     loaded.set(true)
 
     window.api.send("LOADED")
+}
+
+function migrateLegacyConnectionHostnameSetting() {
+    const legacyUseHostname = get(special).connectionHostname
+    if (typeof legacyUseHostname !== "boolean") return
+
+    const connectionIds = ["remote", "stage", "controller", "output_stream"]
+    const currentServerData = clone(get(serverData) || {})
+    const hasPerConnectionSetting = connectionIds.some((id) => typeof currentServerData?.[id]?.useHostname === "boolean")
+    if (hasPerConnectionSetting) return
+
+    connectionIds.forEach((id) => {
+        if (!currentServerData[id]) currentServerData[id] = {}
+        currentServerData[id].useHostname = legacyUseHostname
+    })
+
+    serverData.set(currentServerData)
 }
 
 let videoDataUpdating = false

--- a/src/types/Socket.ts
+++ b/src/types/Socket.ts
@@ -22,4 +22,5 @@ type ClientChannels = "API" | "CONNECTION" | "DISCONNECT" | "ERROR" | "DATA" | "
 export interface ServerData {
     outputId?: string
     sendAudio?: boolean
+    useHostname?: boolean
 }


### PR DESCRIPTION
Fixes global behavior of hostname/IP toggle
Adds per-connection configuration
Allows mixed usage (hostname + IP simultaneously)