### PR TITLE
Add explicit slash for repetitions

### DIFF
--- a/src/electron/contentProviders/planningCenter/request.ts
+++ b/src/electron/contentProviders/planningCenter/request.ts
@@ -553,9 +553,17 @@ function toSectionSourceLine(line: string): SectionSourceLine {
     }
 }
 
+function addRepeatMarkers(source: SectionSourceLine, text: string): string {
+    if (source.markerOnly) return text
+    const startMarker = source.repeatStartCount ? "/".repeat(source.repeatStartCount) : ""
+    const endMarker = source.repeatEndCount ? "/".repeat(source.repeatEndCount) : ""
+    if (!startMarker && !endMarker) return text
+    return `${startMarker}${text}${endMarker}`
+}
+
 function toParsedSectionLine(source: SectionSourceLine, overrides: Partial<ParsedSectionLine> = {}): ParsedSectionLine {
     return {
-        text: source.line.trim(),
+        text: addRepeatMarkers(source, source.line.trim()),
         repeatStartCount: source.repeatStartCount,
         repeatEndCount: source.repeatEndCount,
         hidden: source.markerOnly,
@@ -694,7 +702,7 @@ function parseSectionLines(lyrics: string): ParsedSectionLine[] {
 
         const inline = parseInlineBracketLine(currentLine)
         if (inline && inline.text.trim()) {
-            parsedLines.push(toParsedSectionLine(currentEntry, { text: inline.text.trim(), chords: inline.chords, hidden: false }))
+            parsedLines.push(toParsedSectionLine(currentEntry, { text: addRepeatMarkers(currentEntry, inline.text.trim()), chords: inline.chords, hidden: false }))
             continue
         }
 
@@ -704,7 +712,7 @@ function parseSectionLines(lyrics: string): ParsedSectionLine[] {
             const nextLine = nextEntry.line
             if (canAlignChordLineWithLyricLine(nextLine)) {
                 const alignedLine = alignChordsToLyricLine(chordLineData, nextLine, sectionBaseOffset || 0)
-                parsedLines.push(toParsedSectionLine(nextEntry, { text: alignedLine.text, chords: alignedLine.chords }))
+                parsedLines.push(toParsedSectionLine(nextEntry, { text: addRepeatMarkers(nextEntry, alignedLine.text), chords: alignedLine.chords }))
                 i++
                 continue
             }


### PR DESCRIPTION
When importing songs from Planning Center, lines with repeat markers (e.g., `//Esto se repite//`) had the `//` stripped from slide content — slides were correctly duplicated but the markers were invisible to the congregation.

## Before / After

```
// Planning Center input:
//Esto se repite//

// Before:
SLIDE 1: Esto se repite
SLIDE 2: Esto se repite

// After:
SLIDE 1: //Esto se repite//
SLIDE 2: //Esto se repite//
```

This will help the congregation to know how many repetitions are