### PR TITLE
License expiration

### DIFF
--- a/src/electron/contentProviders/amazingLife/AmazingLifeContentLibrary.ts
+++ b/src/electron/contentProviders/amazingLife/AmazingLifeContentLibrary.ts
@@ -1,7 +1,9 @@
 import { httpsRequest } from "../../utils/requests"
-import type { ContentFile, ContentLibraryCategory } from "../base/types"
+import type { ContentFile, ContentLibraryCategory, MediaLicense } from "../base/types"
 import { AmazingLifeConnect } from "./AmazingLifeConnect"
 import { AMAZING_LIFE_API_BASE } from "./types"
+
+const LICENSE_TTL_MS = 30 * 24 * 60 * 60 * 1000 // 30 days
 
 /**
  * Handles content library operations for AmazingLife (APlay).
@@ -123,10 +125,10 @@ export class AmazingLifeContentLibrary {
     }
 
     /**
-     * Checks if a single media item is licensed
-     * Returns the pingback URL if licensed, null otherwise
+     * Checks if a single media item is licensed.
+     * Returns a MediaLicense (pingback URL + expiration) if licensed, null otherwise.
      */
-    public static async checkMediaLicense(mediaId: string): Promise<string | null> {
+    public static async checkMediaLicense(mediaId: string): Promise<MediaLicense | null> {
         const accessToken = AmazingLifeConnect.getAccessToken()
         if (!accessToken) {
             console.warn("Not authenticated with APlay, cannot check license")
@@ -149,7 +151,7 @@ export class AmazingLifeContentLibrary {
 
                     if (result?.isLicensed) {
                         const pingbackUrl = `${AMAZING_LIFE_API_BASE}/prod/reports/media/${mediaId}/stream-count?source=aplay-pro`
-                        resolve(pingbackUrl)
+                        resolve({ pingbackUrl, expiresAt: Date.now() + LICENSE_TTL_MS })
                     } else {
                         resolve(null)
                     }

--- a/src/electron/contentProviders/amazingLife/AmazingLifeProvider.ts
+++ b/src/electron/contentProviders/amazingLife/AmazingLifeProvider.ts
@@ -1,7 +1,7 @@
 import type express from "express"
 import { getKey } from "../../utils/keys"
 import { ContentProvider } from "../base/ContentProvider"
-import type { ContentFile, ContentLibraryCategory } from "../base/types"
+import type { ContentFile, ContentLibraryCategory, MediaLicense } from "../base/types"
 import { AmazingLifeConnect } from "./AmazingLifeConnect"
 import { AmazingLifeContentLibrary } from "./AmazingLifeContentLibrary"
 import { AMAZING_LIFE_API_URL } from "./types"
@@ -91,10 +91,10 @@ export class AmazingLifeProvider extends ContentProvider<AmazingLifeScopes, Amaz
     }
 
     /**
-     * Checks if a media item is licensed and returns its pingback URL
-     * This should be called when the user actually tries to use/play a media item
+     * Checks if a media item is licensed and returns its pingback URL + expiration.
+     * This should be called when the user actually tries to use/play a media item.
      */
-    async checkMediaLicense(mediaId: string): Promise<string | null> {
+    async checkMediaLicense(mediaId: string): Promise<MediaLicense | null> {
         return AmazingLifeContentLibrary.checkMediaLicense(mediaId)
     }
 

--- a/src/electron/contentProviders/base/ContentProvider.ts
+++ b/src/electron/contentProviders/base/ContentProvider.ts
@@ -1,5 +1,5 @@
 import express from "express"
-import type { ContentFile, ContentLibraryCategory, ContentProviderId } from "./types"
+import type { ContentFile, ContentLibraryCategory, ContentProviderId, MediaLicense } from "./types"
 
 /**
  * Base types for content provider authentication and requests
@@ -97,9 +97,11 @@ export abstract class ContentProvider<TScope extends string = string, TAuthData 
     getContent?(key: string): Promise<ContentFile[]>
 
     /**
-     * Checks if a media item is licensed and returns its pingback URL (optional)
+     * Checks if a media item is licensed and returns its pingback URL + expiration (optional).
+     * Providers that don't implement expiration should return a MediaLicense with
+     * a far-future expiresAt.
      */
-    checkMediaLicense?(mediaId: string): Promise<string | null>
+    checkMediaLicense?(mediaId: string): Promise<MediaLicense | null>
 
     /**
      * Determines if a specific URL from this provider should be encrypted (optional)

--- a/src/electron/contentProviders/base/types.ts
+++ b/src/electron/contentProviders/base/types.ts
@@ -97,6 +97,15 @@ export interface ContentLibraryCategory {
 }
 
 /**
+ * Result of a provider license check. `null` from checkMediaLicense means
+ * the item is not licensed or the check failed.
+ */
+export interface MediaLicense {
+    pingbackUrl: string
+    expiresAt: number // unix ms; license is valid while Date.now() < expiresAt
+}
+
+/**
  * Content file (image or video) with metadata
  */
 export interface ContentFile {

--- a/src/electron/data/protected.ts
+++ b/src/electron/data/protected.ts
@@ -8,14 +8,48 @@ import { ToMain } from "../../types/IPC/ToMain"
 import { ContentProviderFactory } from "../contentProviders/base/ContentProvider"
 import type { ContentProviderId } from "../contentProviders/base/types"
 import { sendToMain } from "../IPC/main"
-import { createFolder, getMimeType } from "../utils/files"
+import { createFolder, deleteFolderAsync, getMimeType } from "../utils/files"
 import { getKey } from "../utils/keys"
+import { appDataPath } from "./store"
 import { filePathHashCode } from "./thumbnails"
 
+const PROTECTED_CACHE_DIR_NAME = "protected-cache"
+const PROTECTED_CACHE_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 30 // 30 days
+
+function getProtectedCacheDir() {
+    return path.join(appDataPath, PROTECTED_CACHE_DIR_NAME)
+}
+
 export function getProtectedPath(url: string) {
-    const protectedDir = path.join(app.getPath("temp"), "freeshow-protected")
+    const protectedDir = getProtectedCacheDir()
     createFolder(protectedDir)
     return path.join(protectedDir, filePathHashCode(url))
+}
+
+export async function cleanupProtectedCache() {
+    const dir = getProtectedCacheDir()
+    try {
+        const entries = await fs.promises.readdir(dir)
+        const now = Date.now()
+        await Promise.all(
+            entries.map(async (name) => {
+                const filePath = path.join(dir, name)
+                try {
+                    const stats = await fs.promises.stat(filePath)
+                    if (now - stats.mtimeMs > PROTECTED_CACHE_MAX_AGE_MS) {
+                        await fs.promises.unlink(filePath)
+                    }
+                } catch {
+                    // ignore per-file errors
+                }
+            })
+        )
+    } catch {
+        // dir may not exist yet — nothing to clean
+    }
+
+    // one-time sweep of the pre-migration temp location from older versions
+    await deleteFolderAsync(path.join(app.getPath("temp"), "freeshow-protected"))
 }
 
 const alg = "aes-256-cbc"
@@ -234,6 +268,11 @@ async function getDecryptedBuffer(entry: ProtectedMediaEntry) {
 
     const decrypted = await decryptFile(entry.filePath, key)
     if (!decrypted) return null
+
+    // Bump the file's mtime so cleanupProtectedCache keeps it for another 30 days.
+    // Only on disk-read path — in-memory cache hits don't count as disk activity.
+    const nowSeconds = Date.now() / 1000
+    fs.promises.utimes(entry.filePath, nowSeconds, nowSeconds).catch(() => null)
 
     decryptedCache.set(entry.id, { buffer: decrypted, timeout: null })
     refreshCache(entry.id)

--- a/src/electron/index.ts
+++ b/src/electron/index.ts
@@ -9,7 +9,7 @@ import type { Dictionary } from "../types/Settings"
 import { receiveAudio } from "./audio/receiveAudio"
 import { cloudConnect } from "./cloud/cloud"
 import { startExport } from "./data/export"
-import { registerProtectedProtocol } from "./data/protected"
+import { cleanupProtectedCache, registerProtectedProtocol } from "./data/protected"
 import { config, setupStores } from "./data/store"
 import { receiveMain, sendMain } from "./IPC/main"
 import { autoErrorReport } from "./IPC/responsesMain"
@@ -110,6 +110,7 @@ async function startApp() {
     await setupStores()
 
     registerProtectedProtocol()
+    cleanupProtectedCache().catch((err) => console.error("Protected cache cleanup failed:", err))
 
     // Start servers initialization early (asynchronously)
     Promise.resolve()

--- a/src/electron/utils/files.ts
+++ b/src/electron/utils/files.ts
@@ -77,6 +77,15 @@ export function deleteFolder(filePath: string) {
     }
 }
 
+export function deleteFolderAsync(filePath: string) {
+    return new Promise<void>((resolve) => {
+        fs.rm(filePath, { recursive: true, force: true }, (err) => {
+            if (err) actionComplete(err, "Error when deleting folder")
+            resolve()
+        })
+    })
+}
+
 export function doesPathExistAsync(filePath: string): Promise<boolean> {
     return new Promise((resolve) => {
         fs.access(filePath, (err) => {

--- a/src/frontend/components/helpers/media.ts
+++ b/src/frontend/components/helpers/media.ts
@@ -737,35 +737,64 @@ export async function downloadOnlineMedia(url: string) {
     const downloadedPath = await requestMain(Main.MEDIA_IS_DOWNLOADED, { url, contentFile: mediaData?.contentFile })
 
     if (downloadedPath?.isDownloading) return url
-    if (downloadedPath?.protectedUrl) return downloadedPath.protectedUrl
+
+    const providerId = mediaData?.contentFile?.providerId
+    const mediaId = mediaData?.contentFile?.mediaId
+    const needsLicense = !!(providerId && mediaId)
+
+    if (downloadedPath?.protectedUrl) {
+        if (!needsLicense || isLicenseValid(mediaData)) return downloadedPath.protectedUrl
+        const refreshed = await refreshMediaLicense(url, providerId, mediaId)
+        if (refreshed) return downloadedPath.protectedUrl
+        return url
+    }
     if (downloadedPath?.path) return downloadedPath.path
 
-    // Check license before downloading (for content providers like APlay)
-    if (mediaData?.contentFile?.mediaId && mediaData?.contentFile?.providerId && !mediaData?.licenseChecked) {
-        media.update((m) => {
-            if (!m[url]) m[url] = {}
-            m[url].licenseChecked = true
-            return m
-        })
+    if (needsLicense && !isLicenseValid(mediaData)) await refreshMediaLicense(url, providerId, mediaId)
 
-        const pingbackUrl = await requestMain(Main.CHECK_MEDIA_LICENSE, {
-            providerId: mediaData.contentFile.providerId,
-            mediaId: mediaData.contentFile.mediaId
-        })
-        if (pingbackUrl) {
-            media.update((m) => {
-                if (!m[url]) m[url] = {}
-                if (!m[url].contentFile) m[url].contentFile = {}
-                m[url].contentFile.pingbackUrl = pingbackUrl
-                return m
-            })
-        }
-    }
-
-    // not downloaded yet - get updated media data in case pingbackUrl was just set
     const updatedMediaData = get(media)[url]
     sendMain(Main.MEDIA_DOWNLOAD, { url, contentFile: updatedMediaData?.contentFile })
     return url
+}
+
+function isLicenseValid(mediaData: MediaStyle | undefined): boolean {
+    const exp = mediaData?.licenseExpiresAt
+    return typeof exp === "number" && exp > Date.now()
+}
+
+// share one IPC call instead of racing.
+const licenseRefreshInFlight = new Map<string, Promise<boolean>>()
+
+function refreshMediaLicense(url: string, providerId: string, mediaId: string): Promise<boolean> {
+    const existing = licenseRefreshInFlight.get(url)
+    if (existing) return existing
+
+    const promise = (async () => {
+        const license = await requestMain(Main.CHECK_MEDIA_LICENSE, { providerId, mediaId })
+        if (!license) {
+            if (get(media)[url]?.licenseExpiresAt !== undefined) {
+                media.update((m) => {
+                    if (m[url]) delete m[url].licenseExpiresAt
+                    return m
+                })
+            }
+            return false
+        }
+
+        media.update((m) => {
+            if (!m[url]) m[url] = {}
+            m[url].licenseExpiresAt = license.expiresAt
+            if (!m[url].contentFile) m[url].contentFile = {}
+            m[url].contentFile.pingbackUrl = license.pingbackUrl
+            return m
+        })
+        return true
+    })().finally(() => {
+        licenseRefreshInFlight.delete(url)
+    })
+
+    licenseRefreshInFlight.set(url, promise)
+    return promise
 }
 
 export async function getMediaFileFromClipboard(e: ClipboardEvent): Promise<string | null> {

--- a/src/types/IPC/Main.ts
+++ b/src/types/IPC/Main.ts
@@ -3,7 +3,7 @@ import type { ExifData } from "exif"
 import type { Stats } from "fs"
 import type { Bible } from "json-bible/lib/Bible"
 import type { SyncProviderId } from "../../electron/cloud/syncManager"
-import type { ContentFile, ContentLibraryCategory, ContentProviderId } from "../../electron/contentProviders/base/types"
+import type { ContentFile, ContentLibraryCategory, ContentProviderId, MediaLicense } from "../../electron/contentProviders/base/types"
 import type { _store } from "../../electron/data/store"
 import type { TimecodeMode } from "../../electron/timecode/timecode"
 import type { ErrorLog, FileFolder, LessonsData, LyricSearchResult, MainFilePaths, Media, OS, Subtitle } from "../Main"
@@ -330,7 +330,7 @@ export interface MainReturnPayloads {
     [Main.GET_CONTENT_PROVIDERS]: { providerId: ContentProviderId; displayName: string; hasContentLibrary: boolean }[]
     [Main.GET_CONTENT_LIBRARY]: Promise<ContentLibraryCategory[]>
     [Main.GET_PROVIDER_CONTENT]: Promise<ContentFile[]>
-    [Main.CHECK_MEDIA_LICENSE]: Promise<string | null>
+    [Main.CHECK_MEDIA_LICENSE]: Promise<MediaLicense | null>
     // Timecode
     [Main.TIMECODE_VALUE]: number | void
     [Main.TIMECODE_AUDIO_DATA]: Buffer | void

--- a/src/types/Main.ts
+++ b/src/types/Main.ts
@@ -185,7 +185,7 @@ export interface MediaStyle {
     tags?: string[] // media tags
     name?: string // display name for content provider media (encrypted videos)
     contentFile?: any // ContentFile from content provider (imported type would create circular dependency)
-    licenseChecked?: boolean // whether license has been checked for this media
+    licenseExpiresAt?: number // unix ms; content provider license is valid while Date.now() < licenseExpiresAt
     pingbackUrl?: string // URL for sending pingback after playback
     cropping?: Partial<Cropping>
 


### PR DESCRIPTION
Having freeshow protected cache folder in the system temp folder was problematic because on Mac that folder is cleared on reboot.  This moves it to appdata/freeshow/protected-cache and adds a functional call on launch to clear anything that hasn't been used in 30 days.

Also, the license to play content downloaded from Amazing Life had no expiration before.  Added a 30 day expiration to the license to that it'll recheck if the subscription is still active.  