### PR TITLE
Refactor architecture check for npm installation

### DIFF
--- a/makesnap
+++ b/makesnap
@@ -3,13 +3,17 @@ set -e
 
 version=$(grep "\"version\"" package.json | cut -d ":" -f 2 | cut -d "\"" -f 2)
 sed -i "s/version:.*/version: ${version}/" config/building/snapcraft.yaml
+arch="$(uname -m)"
 
-if [ "$(uname -m)" = "aarch64" ]; then
+if [ "$arch" = "aarch64" ]; then
   npm run replace-electron
+  # GCC 15 on arm64 can fail compiling @discordjs/opus unless this warning is not treated as an error.
+  CFLAGS="-Wno-error=implicit-function-declaration" npm install
+else
+  npm install
 fi
-npm install
 npm run build
-if [ "$(uname -m)" = "aarch64" ]; then
+if [ "$arch" = "aarch64" ]; then
   npm run pack:arm64
 else
   npm run pack


### PR DESCRIPTION
GCC 15 on arm64 can fail compiling @discordjs/opus unless this warning is not treated as an error.