### PR TITLE
Fix RemoteShow Logo's in Prod

### DIFF
--- a/config/building/vite.config.servers.mjs
+++ b/config/building/vite.config.servers.mjs
@@ -1,7 +1,7 @@
 import { defineConfig } from 'vite'
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import sveltePreprocess from 'svelte-preprocess'
-import { resolve } from 'path'
+import { resolve, dirname } from 'path'
 import { copyFileSync, mkdirSync, existsSync, readFileSync, createReadStream } from 'fs'
 
 const production = process.env.NODE_ENV === 'production'
@@ -93,6 +93,12 @@ function copyServerFiles(id) {
     { src: `src/server/icon.png`, dest: `${dest}/icon.png` },
     { src: `src/server/sw.js`, dest: `${dest}/sw.js` },
   ]
+
+  if (id === 'remote') {
+    files.push(
+      { src: 'public/import-logos/freeshow.webp', dest: `${dest}/import-logos/freeshow.webp` }
+    )
+  }
   
   if (id === 'stage') {
     files.push(
@@ -108,6 +114,10 @@ function copyServerFiles(id) {
   
   files.forEach(({ src, dest }) => {
     try {
+      const destinationDir = dirname(dest)
+      if (!existsSync(destinationDir)) {
+        mkdirSync(destinationDir, { recursive: true })
+      }
       copyFileSync(src, dest)
     } catch (err) {
       console.warn(`Failed to copy ${src} to ${dest}:`, err.message)

--- a/src/server/remote/components/Auth.svelte
+++ b/src/server/remote/components/Auth.svelte
@@ -14,7 +14,7 @@
 <div class="auth-page">
     <div class="panel">
         <div class="brand">
-            <img class="logo" src="./import-logos/freeshow.webp" alt="FreeShow logo" draggable="false" />
+            <img class="logo" src="/import-logos/freeshow.webp" alt="FreeShow logo" draggable="false" />
             <h1>RemoteShow</h1>
         </div>
 


### PR DESCRIPTION
This should work as I can see the webp files during npm run build.
Might have to wait till next release to see if it actually works in prod (unless you can build one and see).
Not sure if it's all necessary

https://github.com/ChurchApps/FreeShow/issues/3241#issuecomment-4441248697