### PR TITLE
fix: show ghost background in slide preview

### DIFF
--- a/src/frontend/components/slide/Slide.svelte
+++ b/src/frontend/components/slide/Slide.svelte
@@ -14,7 +14,7 @@
     import { clone } from "../helpers/array"
     import { getContrast, hexToRgb, splitRgb } from "../helpers/color"
     import Icon from "../helpers/Icon.svelte"
-    import { getMedia, getMediaCached, getMediaStyle, mediaSize } from "../helpers/media"
+    import { getMedia, getMediaStyle, mediaSize } from "../helpers/media"
     import { allOutputsHasStyleTemplate, getActiveOutputs, getFirstActiveOutput, getResolution, getSlideFilter, setTemplateStyle } from "../helpers/output"
     import { getGroupName } from "../helpers/show"
     import { _show } from "../helpers/shows"
@@ -97,8 +97,8 @@
             // ghost thumbnails does not need to be rendered right away
             await wait(50)
 
-            // load ghost thumbnails
-            const media = await getMediaCached(bgPath, ghostSize)
+            // load ghost thumbnails - use getMedia to create if not yet cached
+            const media = await getMedia(bgPath, ghostSize)
             if (!media) return
 
             thumbnailPath = media.thumbnail
@@ -290,7 +290,7 @@
                     relative={viewMode === "lyrics" && !noQuickEdit}
                 >
                     <!-- backgrounds -->
-                    {#if !altKeyPressed && bg && (viewMode !== "lyrics" || noQuickEdit) && (background || layers.includes("background"))}
+                    {#if !altKeyPressed && bg && (viewMode !== "lyrics" || noQuickEdit) && (background || ghostBackground || layers.includes("background"))}
                         {#key $refreshSlideThumbnails}
                             <div class="background" style="zoom: {1 / ratio};{slideFilter}" class:ghost={!background}>
                                 <MediaLoader name={translateText("error.load")} ghost={!background} path={mediaPath} {thumbnailPath} cameraGroup={bg.cameraGroup || ""} type={bg.type !== "player" ? bg.type : null} {mediaStyle} bind:duration getDuration />


### PR DESCRIPTION
## Summary

Two bugs prevented inherited (ghost) backgrounds from rendering in slide preview thumbnails — symptom: ghost slides appeared blank even though the first slide of the song had a background set.

- **Layer guard blocked ghosts.** The render condition required the active output style to have the `background` layer enabled, so disabling the audience background layer also hid the dimmed ghost background in the editor. Added `ghostBackground` to bypass the layer check, since ghosts represent inheritance, not the audience layer.
- **Thumbnail load race.** Ghost slides called `getMediaCached`, which only returns an *already-cached* thumbnail. Slide 0 generates that thumbnail asynchronously without `await`, so within the 50 ms wait ghost slides often got `null` back, leaving `thumbnailPath` empty — and `MediaLoader` explicitly renders nothing for a ghost slide without a thumbnail. Switched to `getMedia`, which generates the thumbnail on demand.

Both fixes are in `src/frontend/components/slide/Slide.svelte`. Diff is 4 lines.

## Test plan

- [x] Open a song with a background set only on the first slide
- [x] Confirm slides 2+ show the inherited background at reduced opacity in the slide preview grid
- [x] In an output style, toggle the `background` Active Layer off — confirm ghost backgrounds still render in the editor preview (only the audience output should hide it)
- [x] Open a fresh show (no cache warm-up) and confirm ghosts appear without needing to click slide 0 first

🤖 Generated with [Claude Code](https://claude.com/claude-code)