### PR TITLE
Fix ControlShow bug where the current slide in Draw mode doesn't get updated when slides are updated via Controller

### DIFF
--- a/src/server/controller/App.svelte
+++ b/src/server/controller/App.svelte
@@ -33,7 +33,11 @@
     let thumbnailInterval: any = null
     let frameReceived = true
     $: if (draw && !thumbnailInterval) thumbnailInterval = setInterval(requestThumbnail, 800)
-    else if (thumbnailInterval) clearInterval(thumbnailInterval)
+        else if (thumbnailInterval) {
+            clearInterval(thumbnailInterval)
+            thumbnailInterval = null
+        } 
+
     function requestThumbnail() {
         if (!outputId || !frameReceived) return
         frameReceived = false


### PR DESCRIPTION
## Issue
In FreeShow ControlShow, both via Web or the FreeShow Remote app, when the slides are updated using the ControlShow-Controller the slide in ControlShow-Draw mode doesn't get updated. Attached a video for reference.
https://github.com/user-attachments/assets/0c0010c5-2081-4d7b-9a59-71d7d38681c4


## Root Cause

When the user opens a ControlShow instance and navigates to Draw mode for the first time, a `setInterval` is initialized that runs every 800ms to request for the current slide that's being shown (`requestThumbnail`).
```ts
    $: if (draw && !thumbnailInterval) thumbnailInterval = setInterval(requestThumbnail, 800)
    else if (thumbnailInterval) clearInterval(thumbnailInterval)
```
*https://github.com/ChurchApps/FreeShow/blob/main/src/server/controller/App.svelte#L35-L36*

The issue occurs when the user goes back to the Controller mode since, when this happens, the `else if` block is triggered and `thumbnailInterval` is stopped with the `clearInterval`. But even if it the interval has stopped, `thumbnailInterval` is still holding the random integer value (intervalID) that was assigned during `setInterval`.
So when the user goes back to Draw mode again, the execution won't go through the `if` block since even if `draw` is `true` `thumbnailInterval` is still holding the original random positive integer it was set with during the first `setInterval` which causes the `if` condition to fail. And when this happens, the `setInterval` for `requestThumbnail` in the `if` block won't get re-initiated that causes the requests for new thumbnail slides to not happen. Thus, the issue.


## Proposed Fix
In addition to the `clearInterval` on the `else if` block, the `thumbnailInterval` should also be set back to `null`. This way when the user navigates back to the Draw mode from the Controller mode, the `if` condition would pass and the `setInterval` for `requestThumbnail` will be re-initiated.