### PR TITLE
test(sync): unit tests + pure module for per-item SYNCED_SETTINGS merge

### DIFF
--- a/config/testing/vitest.config.ts
+++ b/config/testing/vitest.config.ts
@@ -1,0 +1,13 @@
+import { fileURLToPath } from "node:url"
+import { defineConfig } from "vitest/config"
+
+// Unit tests live alongside source as *.test.ts under src/.
+// The Playwright e2e (config/testing/start.test.ts) is excluded — it uses @playwright/test.
+// This config sits in config/testing/, so point the root back at the project root.
+export default defineConfig({
+    root: fileURLToPath(new URL("../../", import.meta.url)),
+    test: {
+        include: ["src/**/*.test.ts"],
+        environment: "node"
+    }
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,6 +102,7 @@
                 "tslib": "^2.8.1",
                 "typescript": "^4.9.5",
                 "vite": "^4.5.14",
+                "vitest": "^2.1.9",
                 "xml2js": "^0.6.2",
                 "youtube-player": "^5.6.0"
             },
@@ -177,6 +178,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -198,6 +200,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -643,7 +646,6 @@
             "dev": true,
             "license": "BSD-2-Clause",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "cross-dirname": "^0.1.0",
                 "debug": "^4.3.4",
@@ -665,7 +667,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^6.0.1",
@@ -686,6 +687,23 @@
             },
             "engines": {
                 "node": "^14 || ^16 || ^17 || ^18 || ^19"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@esbuild/android-arm": {
@@ -1857,6 +1875,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -1878,6 +1897,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.2.0.tgz",
             "integrity": "sha512-qRkLWiUEZNAmYapZ7KGS5C4OmBLcP/H2foXeOEaowYCR0wi89fHejrfYfbuLVCMLp/dWZXKvQusdbUEZjERfwQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
             },
@@ -1890,6 +1910,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.2.0.tgz",
             "integrity": "sha512-FuabnnUm8LflnieVxs6eP7Z383hgQU4W1e3KJS6aOG3RxWxcHyBxH8fDMHNgu/gFx/M2jvTOW/4/PHhLz6bjWw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -1905,6 +1926,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
             "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.208.0",
                 "import-in-the-middle": "^2.0.0",
@@ -2292,6 +2314,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.2.0.tgz",
             "integrity": "sha512-1pNQf/JazQTMA0BiO5NINUzH0cbLbbl7mntLa4aJNmCCXSj0q03T5ZXXL0zw4G55TjdL9Tz32cznGClf+8zr5A==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -2308,6 +2331,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.2.0.tgz",
             "integrity": "sha512-xWQgL0Bmctsalg6PaXExmzdedSp3gyKV8mQBwK/j9VGdCDu2fmXIb2gAehBKbkXCpJ4HPkgv3QfoJWRT4dHWbw==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.2.0",
                 "@opentelemetry/resources": "2.2.0",
@@ -2325,6 +2349,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
             "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -3161,6 +3186,7 @@
             "version": "2.5.3",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sveltejs/vite-plugin-svelte-inspector": "^1.0.4",
                 "debug": "^4.3.4",
@@ -3612,6 +3638,7 @@
             "version": "5.62.0",
             "dev": true,
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -3769,6 +3796,92 @@
                 "weakmap-polyfill": "2.0.4"
             }
         },
+        "node_modules/@vitest/expect": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+            "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "2.1.9",
+                "@vitest/utils": "2.1.9",
+                "chai": "^5.1.2",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/pretty-format": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+            "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/runner": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+            "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/utils": "2.1.9",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/snapshot": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+            "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.9",
+                "magic-string": "^0.30.12",
+                "pathe": "^1.1.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/spy": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+            "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tinyspy": "^3.0.2"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vitest/utils": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+            "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/pretty-format": "2.1.9",
+                "loupe": "^3.1.2",
+                "tinyrainbow": "^1.2.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
         "node_modules/@xmldom/xmldom": {
             "version": "0.8.13",
             "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
@@ -3814,6 +3927,7 @@
         "node_modules/acorn": {
             "version": "8.15.0",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -3851,6 +3965,7 @@
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4323,6 +4438,16 @@
                 "node": ">=0.8"
             }
         },
+        "node_modules/assertion-error": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/astral-regex": {
             "version": "2.0.0",
             "dev": true,
@@ -4750,6 +4875,16 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/cac": {
+            "version": "6.7.14",
+            "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+            "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cacache": {
             "version": "19.0.1",
             "resolved": "https://registry.npmjs.org/cacache/-/cacache-19.0.1.tgz",
@@ -5001,6 +5136,23 @@
                 "node": ">=6"
             }
         },
+        "node_modules/chai": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+            "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/chalk": {
             "version": "4.1.2",
             "license": "MIT",
@@ -5013,6 +5165,16 @@
             },
             "funding": {
                 "url": "https://github.com/chalk/chalk?sponsor=1"
+            }
+        },
+        "node_modules/check-error": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+            "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -5517,8 +5679,7 @@
             "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
             "dev": true,
             "license": "MIT",
-            "optional": true,
-            "peer": true
+            "optional": true
         },
         "node_modules/cross-env": {
             "version": "7.0.3",
@@ -5729,6 +5890,16 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/deep-eql": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+            "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/deep-extend": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
@@ -5893,6 +6064,7 @@
             "integrity": "sha512-glMJgnTreo8CFINujtAhCgN96QAqApDMZ8Vl1r8f0QT8QprvC1UCltV4CcWj20YoIyLZx6IUskaJZ0NV8fokcg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "app-builder-lib": "26.8.1",
                 "builder-util": "26.8.1",
@@ -6303,7 +6475,6 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@electron/asar": "^3.2.1",
                 "debug": "^4.1.1",
@@ -6324,7 +6495,6 @@
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -6340,7 +6510,6 @@
             "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
             }
@@ -6351,7 +6520,6 @@
             "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">= 4.0.0"
             }
@@ -6382,14 +6550,6 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 0.8"
-            }
-        },
-        "node_modules/encoding": {
-            "version": "0.1.13",
-            "license": "MIT",
-            "optional": true,
-            "dependencies": {
-                "iconv-lite": "^0.6.2"
             }
         },
         "node_modules/end-of-stream": {
@@ -6559,6 +6719,13 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/es-module-lexer": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+            "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/es-object-atoms": {
             "version": "1.1.1",
             "license": "MIT",
@@ -6676,6 +6843,7 @@
             "version": "8.57.1",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -7014,6 +7182,16 @@
             "license": "(MIT OR WTFPL)",
             "engines": {
                 "node": ">=6"
+            }
+        },
+        "node_modules/expect-type": {
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+            "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=12.0.0"
             }
         },
         "node_modules/exponential-backoff": {
@@ -8319,7 +8497,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "domelementtype": "^2.3.0",
                 "domhandler": "^5.0.3",
@@ -9064,8 +9241,7 @@
         "node_modules/js-tokens": {
             "version": "9.0.1",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/js-yaml": {
             "version": "4.1.1",
@@ -9413,6 +9589,13 @@
         "node_modules/long": {
             "version": "5.3.2",
             "license": "Apache-2.0"
+        },
+        "node_modules/loupe": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+            "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/lowercase-keys": {
             "version": "2.0.0",
@@ -10842,6 +11025,23 @@
                 "node": ">=8"
             }
         },
+        "node_modules/pathe": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+            "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/pathval": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+            "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14.16"
+            }
+        },
         "node_modules/pause-stream": {
             "version": "0.0.11",
             "license": [
@@ -11115,6 +11315,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.11",
                 "picocolors": "^1.1.1",
@@ -11148,7 +11349,6 @@
             "version": "6.0.0",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=12.0"
             },
@@ -11164,6 +11364,7 @@
             "version": "7.1.0",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
                 "util-deprecate": "^1.0.2"
@@ -11223,7 +11424,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "dependencies": {
                 "commander": "^9.4.0"
             },
@@ -11241,7 +11441,6 @@
             "dev": true,
             "license": "MIT",
             "optional": true,
-            "peer": true,
             "engines": {
                 "node": "^12.20.0 || >=14"
             }
@@ -11284,6 +11483,7 @@
             "version": "3.6.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -11911,6 +12111,7 @@
             "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -12600,6 +12801,13 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
+        "node_modules/siginfo": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+            "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+            "dev": true,
+            "license": "ISC"
+        },
         "node_modules/signal-exit": {
             "version": "4.1.0",
             "license": "ISC",
@@ -12951,6 +13159,13 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
+        "node_modules/stackback": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+            "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/stat-mode": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/stat-mode/-/stat-mode-1.0.0.tgz",
@@ -12967,6 +13182,13 @@
             "engines": {
                 "node": ">= 0.8"
             }
+        },
+        "node_modules/std-env": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+            "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/stop-iteration-iterator": {
             "version": "1.1.0",
@@ -13198,6 +13420,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@csstools/css-parser-algorithms": "^3.0.5",
                 "@csstools/css-tokenizer": "^3.0.4",
@@ -13389,6 +13612,7 @@
             "version": "3.59.2",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 8"
             }
@@ -13636,7 +13860,6 @@
             "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "mkdirp": "^0.5.1",
                 "rimraf": "~2.6.2"
@@ -13677,7 +13900,6 @@
             "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "minimist": "^1.2.6"
             },
@@ -13692,7 +13914,6 @@
             "deprecated": "Rimraf versions prior to v4 are no longer supported",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "glob": "^7.1.3"
             },
@@ -13759,6 +13980,20 @@
             "version": "2.1.0",
             "license": "MIT"
         },
+        "node_modules/tinybench": {
+            "version": "2.9.0",
+            "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+            "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/tinyexec": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+            "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tinyglobby": {
             "version": "0.2.15",
             "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -13774,6 +14009,36 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/SuperchupuDev"
+            }
+        },
+        "node_modules/tinypool": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+            "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            }
+        },
+        "node_modules/tinyrainbow": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+            "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
+            }
+        },
+        "node_modules/tinyspy": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+            "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=14.0.0"
             }
         },
         "node_modules/tmp": {
@@ -13850,7 +14115,8 @@
         "node_modules/tslib": {
             "version": "2.8.1",
             "dev": true,
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsutils": {
             "version": "3.21.0",
@@ -14000,6 +14266,7 @@
             "version": "4.9.5",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
@@ -14185,6 +14452,7 @@
             "version": "4.5.14",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.18.10",
                 "postcss": "^8.4.27",
@@ -14235,6 +14503,517 @@
                 }
             }
         },
+        "node_modules/vite-node": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+            "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cac": "^6.7.14",
+                "debug": "^4.3.7",
+                "es-module-lexer": "^1.5.4",
+                "pathe": "^1.1.2",
+                "vite": "^5.0.0"
+            },
+            "bin": {
+                "vite-node": "vite-node.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vite-node/node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
+            }
+        },
+        "node_modules/vite-node/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/vite-node/node_modules/vite": {
+            "version": "5.4.21",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
+                    "optional": true
+                }
+            }
+        },
         "node_modules/vite/node_modules/rollup": {
             "version": "3.30.0",
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.30.0.tgz",
@@ -14261,6 +15040,598 @@
             },
             "peerDependenciesMeta": {
                 "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+            "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/expect": "2.1.9",
+                "@vitest/mocker": "2.1.9",
+                "@vitest/pretty-format": "^2.1.9",
+                "@vitest/runner": "2.1.9",
+                "@vitest/snapshot": "2.1.9",
+                "@vitest/spy": "2.1.9",
+                "@vitest/utils": "2.1.9",
+                "chai": "^5.1.2",
+                "debug": "^4.3.7",
+                "expect-type": "^1.1.0",
+                "magic-string": "^0.30.12",
+                "pathe": "^1.1.2",
+                "std-env": "^3.8.0",
+                "tinybench": "^2.9.0",
+                "tinyexec": "^0.3.1",
+                "tinypool": "^1.0.1",
+                "tinyrainbow": "^1.2.0",
+                "vite": "^5.0.0",
+                "vite-node": "2.1.9",
+                "why-is-node-running": "^2.3.0"
+            },
+            "bin": {
+                "vitest": "vitest.mjs"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "@edge-runtime/vm": "*",
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "@vitest/browser": "2.1.9",
+                "@vitest/ui": "2.1.9",
+                "happy-dom": "*",
+                "jsdom": "*"
+            },
+            "peerDependenciesMeta": {
+                "@edge-runtime/vm": {
+                    "optional": true
+                },
+                "@types/node": {
+                    "optional": true
+                },
+                "@vitest/browser": {
+                    "optional": true
+                },
+                "@vitest/ui": {
+                    "optional": true
+                },
+                "happy-dom": {
+                    "optional": true
+                },
+                "jsdom": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+            "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+            "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/android-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+            "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+            "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+            "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+            "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+            "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+            "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+            "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+            "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+            "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+            "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+            "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+            "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+            "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+            "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+            "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+            "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+            "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+            "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+            "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/vitest/node_modules/@vitest/mocker": {
+            "version": "2.1.9",
+            "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+            "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@vitest/spy": "2.1.9",
+                "estree-walker": "^3.0.3",
+                "magic-string": "^0.30.12"
+            },
+            "funding": {
+                "url": "https://opencollective.com/vitest"
+            },
+            "peerDependencies": {
+                "msw": "^2.4.9",
+                "vite": "^5.0.0"
+            },
+            "peerDependenciesMeta": {
+                "msw": {
+                    "optional": true
+                },
+                "vite": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/vitest/node_modules/esbuild": {
+            "version": "0.21.5",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+            "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.21.5",
+                "@esbuild/android-arm": "0.21.5",
+                "@esbuild/android-arm64": "0.21.5",
+                "@esbuild/android-x64": "0.21.5",
+                "@esbuild/darwin-arm64": "0.21.5",
+                "@esbuild/darwin-x64": "0.21.5",
+                "@esbuild/freebsd-arm64": "0.21.5",
+                "@esbuild/freebsd-x64": "0.21.5",
+                "@esbuild/linux-arm": "0.21.5",
+                "@esbuild/linux-arm64": "0.21.5",
+                "@esbuild/linux-ia32": "0.21.5",
+                "@esbuild/linux-loong64": "0.21.5",
+                "@esbuild/linux-mips64el": "0.21.5",
+                "@esbuild/linux-ppc64": "0.21.5",
+                "@esbuild/linux-riscv64": "0.21.5",
+                "@esbuild/linux-s390x": "0.21.5",
+                "@esbuild/linux-x64": "0.21.5",
+                "@esbuild/netbsd-x64": "0.21.5",
+                "@esbuild/openbsd-x64": "0.21.5",
+                "@esbuild/sunos-x64": "0.21.5",
+                "@esbuild/win32-arm64": "0.21.5",
+                "@esbuild/win32-ia32": "0.21.5",
+                "@esbuild/win32-x64": "0.21.5"
+            }
+        },
+        "node_modules/vitest/node_modules/estree-walker": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+            "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/estree": "^1.0.0"
+            }
+        },
+        "node_modules/vitest/node_modules/fsevents": {
+            "version": "2.3.3",
+            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+            "dev": true,
+            "hasInstallScript": true,
+            "license": "MIT",
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+            }
+        },
+        "node_modules/vitest/node_modules/vite": {
+            "version": "5.4.21",
+            "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+            "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "esbuild": "^0.21.3",
+                "postcss": "^8.4.43",
+                "rollup": "^4.20.0"
+            },
+            "bin": {
+                "vite": "bin/vite.js"
+            },
+            "engines": {
+                "node": "^18.0.0 || >=20.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/vitejs/vite?sponsor=1"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            },
+            "peerDependencies": {
+                "@types/node": "^18.0.0 || >=20.0.0",
+                "less": "*",
+                "lightningcss": "^1.21.0",
+                "sass": "*",
+                "sass-embedded": "*",
+                "stylus": "*",
+                "sugarss": "*",
+                "terser": "^5.4.0"
+            },
+            "peerDependenciesMeta": {
+                "@types/node": {
+                    "optional": true
+                },
+                "less": {
+                    "optional": true
+                },
+                "lightningcss": {
+                    "optional": true
+                },
+                "sass": {
+                    "optional": true
+                },
+                "sass-embedded": {
+                    "optional": true
+                },
+                "stylus": {
+                    "optional": true
+                },
+                "sugarss": {
+                    "optional": true
+                },
+                "terser": {
                     "optional": true
                 }
             }
@@ -14387,6 +15758,23 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/why-is-node-running": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+            "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "siginfo": "^2.0.0",
+                "stackback": "0.0.2"
+            },
+            "bin": {
+                "why-is-node-running": "cli.js"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/wide-align": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "pack:arm64": "electron-builder --config config/building/electron-builder-lnxarm.yaml --dir",
         "replace-electron": "node config/building/electron-replace-lnxarm.js",
         "---CHECKING---": "",
-        "test": "npm-run-all -s test:playwright test:format test:svelte",
+        "test": "npm-run-all -s test:unit test:playwright test:format test:svelte",
+        "test:unit": "vitest run --config config/testing/vitest.config.ts",
         "test:playwright": "npx playwright test --config config/testing/playwright.config.ts",
         "test:format": "npx prettier --config config/formatting/.prettierrc.yaml --check src scripts",
         "test:svelte": "svelte-check",
@@ -111,6 +112,7 @@
         "tslib": "^2.8.1",
         "typescript": "^4.9.5",
         "vite": "^4.5.14",
+        "vitest": "^2.1.9",
         "xml2js": "^0.6.2",
         "youtube-player": "^5.6.0"
     },

--- a/src/electron/cloud/syncLedger.test.ts
+++ b/src/electron/cloud/syncLedger.test.ts
@@ -1,0 +1,163 @@
+import { describe, it, expect } from "vitest"
+import { SyncLedger, type Changes } from "./syncLedger"
+
+const ID = "SYNCED_SETTINGS"
+const KEY = "scriptures/x"
+const INST = "SYNCED_SETTINGS_scriptures/x"
+
+function makeChanges(devices: string[], overrides: Partial<Changes> = {}): Changes {
+    return { version: "0.1.1", devices, modified: {}, deleted: {}, created: {}, ...overrides }
+}
+
+describe("SyncLedger — per-item merge (#3335)", () => {
+    describe("union (items unique to a device survive)", () => {
+        it("a brand-new local item is uploaded and marked created", () => {
+            const changes = makeChanges(["A", "B"])
+            const a = new SyncLedger({ changes, deviceId: "A" })
+
+            expect(a.resolveLocalEntry(ID, KEY).action).toBe("upload")
+            expect(changes.created[INST]).toContain("A")
+        })
+
+        it("an item created by another device (cloud-only here) is downloaded, not dropped", () => {
+            // local ledger already merged the cloud's "created by A"
+            const changes = makeChanges(["A", "B"], { created: { [INST]: ["A"] } })
+            const b = new SyncLedger({ changes, deviceId: "B" })
+
+            expect(b.resolveCloudEntry(ID, KEY, /* localExists */ false).action).toBe("create")
+        })
+
+        it("two devices adding different items both keep theirs (no whole-file overwrite)", () => {
+            const changes = makeChanges(["A", "B"])
+            const a = new SyncLedger({ changes, deviceId: "A" })
+            // A has item X (local only) and item Y (created by B, in cloud only)
+            changes.created["SYNCED_SETTINGS_categories/y"] = ["B"]
+
+            expect(a.resolveLocalEntry(ID, "categories/x").action).toBe("upload") // A's own survives
+            expect(a.resolveCloudEntry(ID, "categories/y", false).action).toBe("create") // B's downloaded
+        })
+    })
+
+    describe("deletion propagates (the maintainer's concern: a deleted item must not come back)", () => {
+        it("an item marked deleted that still exists locally is deleted (propagated)", () => {
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const b = new SyncLedger({ changes, deviceId: "B" })
+
+            expect(b.resolveCloudEntry(ID, KEY, /* localExists */ true).action).toBe("delete")
+        })
+
+        it("an item marked deleted and missing locally is skipped (stays deleted, no resurrection)", () => {
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const b = new SyncLedger({ changes, deviceId: "B" })
+
+            expect(b.resolveCloudEntry(ID, KEY, /* localExists */ false).action).toBe("skip")
+        })
+
+        it("an item that exists on both sides and is not deleted is kept (upload) for the caller to tie-break by date", () => {
+            const changes = makeChanges(["A", "B"])
+            const b = new SyncLedger({ changes, deviceId: "B" })
+
+            expect(b.resolveCloudEntry(ID, KEY, /* localExists */ true).action).toBe("upload")
+        })
+    })
+
+    describe("tombstone vs re-create (the edge case we found with the re-imported bible)", () => {
+        it("re-importing a tombstoned item, by a device that did NOT delete it, drops it (current behavior)", () => {
+            // X was deleted by A; cloud ledger reflects that. B re-imports X locally.
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const cloudChanges = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const b = new SyncLedger({ changes, cloudChanges, deviceId: "B" })
+
+            expect(b.isDeletedLocally(ID, KEY)).toBe(false) // B never deleted it
+            expect(b.resolveLocalEntry(ID, KEY).action).toBe("delete") // → dropped (the "phantom bible")
+        })
+
+        it("restoring an item the device itself deleted revives it", () => {
+            // B deleted X (cloud ledger has B), then restores it locally
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["B"] } })
+            const cloudChanges = makeChanges(["A", "B"], { deleted: { [INST]: ["B"] } })
+            const b = new SyncLedger({ changes, cloudChanges, deviceId: "B" })
+
+            expect(b.isDeletedLocally(ID, KEY)).toBe(true)
+            expect(b.resolveLocalEntry(ID, KEY).action).toBe("upload") // revived
+            expect(changes.created[INST]).toContain("B")
+        })
+    })
+
+    describe("ledger mechanics", () => {
+        it("does not track changes with a single device", () => {
+            const changes = makeChanges(["A"])
+            const a = new SyncLedger({ changes, deviceId: "A" })
+            a.markAsCreated(ID, KEY)
+            expect(changes.created[INST]).toBeUndefined()
+        })
+
+        it("marking created clears a prior deleted mark (and vice versa)", () => {
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const a = new SyncLedger({ changes, deviceId: "A" })
+            a.markAsCreated(ID, KEY)
+            expect(changes.deleted[INST]).toBeUndefined()
+            expect(changes.created[INST]).toContain("A")
+        })
+
+        it("drops the entry once every device has acknowledged the change", () => {
+            // A already marked deleted; when B (the last device) also marks it, the entry is removed
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const b = new SyncLedger({ changes, deviceId: "B" })
+            b.markAsDeleted(ID, KEY)
+            expect(changes.deleted[INST]).toBeUndefined()
+        })
+    })
+
+    describe("new device adopts everything (no deletions)", () => {
+        it("creates cloud items and never deletes when isNewDevice", () => {
+            const changes = makeChanges(["A", "B"], { deleted: { [INST]: ["A"] } })
+            const fresh = new SyncLedger({ changes, deviceId: "C", isNewDevice: true })
+            // even a tombstoned item present in the cloud is created, not skipped/deleted
+            expect(fresh.resolveCloudEntry(ID, KEY, false).action).toBe("create")
+        })
+    })
+
+    // The regression for #3335 itself: the SAME input that the old whole-file overwrite lost,
+    // is now preserved by the per-item merge.
+    describe("regression: the #3335 bug (whole-file overwrite dropped a device's items)", () => {
+        // cloud (device A) is "rich": has an English bible 'eng' that device B never had.
+        const cloud: Record<string, { name: string }> = { rv: { name: "Reina-Valera 1960" }, ntv: { name: "NTV" }, eng: { name: "King James" } }
+        // device B is "poor" but added its own item 'zz'.
+        const local: Record<string, { name: string }> = { rv: { name: "Reina-Valera 1960" }, ntv: { name: "NTV" }, zz: { name: "B's new bible" } }
+
+        it("OLD behavior (whole-object overwrite, newest file wins) LOSES the other device's item", () => {
+            // B's file is the most recent → it replaced the whole collection in the cloud
+            const oldResult = { ...local }
+            expect(oldResult.eng).toBeUndefined() // ← King James (A's) is gone: the bug
+            expect(Object.keys(oldResult).sort()).toEqual(["ntv", "rv", "zz"])
+        })
+
+        it("NEW behavior (per-item ledger merge) keeps BOTH devices' items — bug fixed", () => {
+            // in real use the ledger records who created what: A created 'eng', B created 'zz'
+            const changes = makeChanges(["A", "B"], {
+                created: {
+                    "SYNCED_SETTINGS_scriptures/eng": ["A"],
+                    "SYNCED_SETTINGS_scriptures/zz": ["B"]
+                }
+            })
+            const ledger = new SyncLedger({ changes, deviceId: "B" })
+            const merged = ledger.mergeCollection(ID, "scriptures", cloud, local)
+
+            expect(merged.eng).toBeDefined() // A's King James survives
+            expect(merged.zz).toBeDefined() // B's new bible survives
+            expect(Object.keys(merged).sort()).toEqual(["eng", "ntv", "rv", "zz"]) // full union, no loss
+        })
+
+        it("NEW behavior still propagates a real deletion (doesn't blindly union)", () => {
+            // 'eng' was actually deleted (marked in the ledger), B still has it locally
+            const changes = makeChanges(["A", "B"], { deleted: { "SYNCED_SETTINGS_scriptures/eng": ["A"] } })
+            const localWithEng = { rv: { name: "RV" }, eng: { name: "King James" } }
+            const cloudWithoutEng = { rv: { name: "RV" } }
+            const ledger = new SyncLedger({ changes, deviceId: "B" })
+            const merged = ledger.mergeCollection(ID, "scriptures", cloudWithoutEng, localWithEng)
+
+            expect(merged.eng).toBeUndefined() // deletion propagated, not resurrected
+        })
+    })
+})

--- a/src/electron/cloud/syncLedger.ts
+++ b/src/electron/cloud/syncLedger.ts
@@ -1,0 +1,195 @@
+// ----- FreeShow -----
+// Pure, testable per-item merge ledger for SYNCED_SETTINGS / collections.
+//
+// This extracts the created/deleted ledger decision logic from syncManager (see #3335) into a
+// self-contained unit with NO module globals and NO I/O: all state (changes, cloudChanges, the
+// current deviceId, device count) is provided to the constructor, so the merge decisions can be
+// unit-tested in isolation. syncManager delegates to this instead of keeping the logic inline.
+
+export type Changes = {
+    version: string
+    devices: string[]
+    modified: { [key: string]: number }
+    deleted: { [key: string]: string[] }
+    created: { [key: string]: string[] }
+}
+
+export type EntryAction = "create" | "download" | "upload" | "delete" | "skip"
+
+export type LedgerInit = {
+    changes: Changes // local ledger (mutated as items are marked created/deleted)
+    cloudChanges?: Changes | null // ledger as it came from the cloud (read-only here)
+    deviceId: string
+    isNewDevice?: boolean
+}
+
+export class SyncLedger {
+    changes: Changes
+    cloudChanges: Changes | null
+    readonly deviceId: string
+    readonly isNewDevice: boolean
+
+    // items deleted during THIS run; used so a same-run deletion isn't treated as "deleted locally"
+    private deletedNow: string[] = []
+
+    constructor(init: LedgerInit) {
+        this.changes = init.changes
+        this.cloudChanges = init.cloudChanges ?? null
+        this.deviceId = init.deviceId
+        this.isNewDevice = !!init.isNewDevice
+    }
+
+    static instanceId(storeId: string, key: string) {
+        return `${storeId}_${key}`
+    }
+
+    // ----- ledger queries -----
+
+    isDeleted(storeId: string, key: string): boolean {
+        return !!this.changes.deleted?.[SyncLedger.instanceId(storeId, key)]
+    }
+
+    isCreated(storeId: string, key: string): boolean {
+        return !!this.changes.created?.[SyncLedger.instanceId(storeId, key)]
+    }
+
+    // was the item already deleted by THIS device (per the cloud ledger), and not re-deleted this run
+    isDeletedLocally(storeId: string, key: string): boolean {
+        const instanceId = SyncLedger.instanceId(storeId, key)
+        if (this.deletedNow.includes(instanceId)) return false
+        return !!this.cloudChanges?.deleted?.[instanceId]?.includes(this.deviceId)
+    }
+
+    isCreatedLocally(storeId: string, key: string): boolean {
+        const instanceId = SyncLedger.instanceId(storeId, key)
+        return !!this.cloudChanges?.created?.[instanceId]?.includes(this.deviceId)
+    }
+
+    // ----- ledger mutations -----
+
+    markAsDeleted(storeId: string, key: string) {
+        const instanceId = SyncLedger.instanceId(storeId, key)
+        this.unmarkAsCreated(storeId, key)
+        this.markAs("deleted", instanceId)
+        this.deletedNow.push(instanceId)
+    }
+
+    markAsCreated(storeId: string, key: string) {
+        const instanceId = SyncLedger.instanceId(storeId, key)
+        this.unmarkAsDeleted(storeId, key)
+        this.markAs("created", instanceId)
+    }
+
+    private markAs(type: "deleted" | "created", instanceId: string) {
+        // with a single device there's nothing to reconcile, so don't track
+        if (this.changes.devices.length < 2) return
+
+        if (!this.changes[type]) this.changes[type] = {}
+        if (!this.changes[type][instanceId]) this.changes[type][instanceId] = []
+
+        if (this.changes[type][instanceId].includes(this.deviceId)) return
+        this.changes[type][instanceId].push(this.deviceId)
+
+        // once every device has acknowledged the change, drop the entry
+        if (this.changes[type][instanceId].length >= this.changes.devices.length) {
+            delete this.changes[type][instanceId]
+        }
+    }
+
+    private unmarkAsDeleted(storeId: string, key: string) {
+        if (!this.changes.deleted) return
+        delete this.changes.deleted[SyncLedger.instanceId(storeId, key)]
+    }
+
+    private unmarkAsCreated(storeId: string, key: string) {
+        if (!this.changes.created) return
+        delete this.changes.created[SyncLedger.instanceId(storeId, key)]
+    }
+
+    // ----- merge decisions (item-collections with no per-item "modified") -----
+
+    // Item present in the cloud snapshot; decide create/skip/delete/keep given whether it exists locally.
+    // Single source of truth for the ledger decision: syncManager.checkCloudEntry delegates here.
+    // An "upload" result means "keep local for now" — for entries that carry a per-item "modified",
+    // the caller then breaks the tie by date (download if the cloud copy is newer).
+    resolveCloudEntry(storeId: string, key: string, localExists: boolean): { action: EntryAction } {
+        // exists only in cloud
+        if (!localExists) {
+            if (this.isNewDevice) return { action: "create" }
+
+            if (this.isCreated(storeId, key) && this.isCreatedLocally(storeId, key)) {
+                // previously created here but now missing → it was deleted locally
+                this.markAsDeleted(storeId, key)
+                return { action: "skip" }
+            }
+            if (this.isCreated(storeId, key)) {
+                this.markAsCreated(storeId, key)
+                return { action: "create" }
+            }
+            if (this.isDeleted(storeId, key)) {
+                this.markAsDeleted(storeId, key)
+                return { action: "skip" }
+            }
+            // absence with no ledger mark → treat as deleted locally
+            this.markAsDeleted(storeId, key)
+            return { action: "skip" }
+        }
+
+        // exists locally and in cloud, but is marked deleted → propagate the deletion
+        if (this.isDeleted(storeId, key) && !this.isNewDevice) {
+            this.markAsDeleted(storeId, key)
+            return { action: "delete" }
+        }
+        if (this.isCreated(storeId, key)) this.markAsCreated(storeId, key)
+
+        // exists on both sides and not deleted → keep local; the caller may override to "download"
+        // by modified time (collections have no per-item "modified", so they stay as upload)
+        return { action: "upload" }
+    }
+
+    // Item present only locally (not in the cloud snapshot).
+    // Single source of truth for the ledger decision: syncManager.checkLocalEntry delegates here.
+    resolveLocalEntry(storeId: string, key: string): { action: EntryAction } {
+        if (this.isNewDevice) return { action: "upload" }
+
+        if (this.isDeleted(storeId, key)) {
+            // this device had deleted it then restored it → revive
+            if (this.isDeletedLocally(storeId, key)) {
+                this.markAsCreated(storeId, key)
+                return { action: "upload" }
+            }
+            // someone else deleted it → propagate the deletion locally
+            this.markAsDeleted(storeId, key)
+            return { action: "delete" }
+        }
+
+        // brand-new local item → mark created so other devices download it
+        this.markAsCreated(storeId, key)
+        return { action: "upload" }
+    }
+
+    // Merge one item-collection (e.g. scriptures) per-item: applies the cloud entries onto the local
+    // object and resolves local-only items via the ledger. Returns the merged collection.
+    // This is the per-item replacement for the old whole-object overwrite that caused #3335.
+    mergeCollection(storeId: string, type: string, cloudObj: Record<string, any>, localObj: Record<string, any>): Record<string, any> {
+        const merged: Record<string, any> = { ...localObj }
+
+        // items present in the cloud
+        for (const [key, value] of Object.entries(cloudObj || {})) {
+            const itemKey = `${type}/${key}`
+            const action = this.resolveCloudEntry(storeId, itemKey, key in merged).action
+            if (action === "delete") delete merged[key]
+            else if (action === "create" || action === "download") merged[key] = value
+        }
+
+        // items present only locally
+        for (const key of Object.keys(localObj || {})) {
+            if (key in (cloudObj || {})) continue
+            const itemKey = `${type}/${key}`
+            const action = this.resolveLocalEntry(storeId, itemKey).action
+            if (action === "delete") delete merged[key]
+        }
+
+        return merged
+    }
+}

--- a/src/electron/cloud/syncManager.ts
+++ b/src/electron/cloud/syncManager.ts
@@ -11,6 +11,7 @@ import { sendMain } from "../IPC/main"
 import { createFolder, deleteFile, deleteFolderAsync, doesPathExistAsync, getDataFolderPath, getFileStatsAsync, getTimePointString, loadShows, moveFileAsync, readFileAsync, readFolderAsync, writeFileAsync } from "../utils/files"
 import { clone, getMachineId } from "../utils/helpers"
 import { getChurchAppsSyncManager } from "./ChurchAppsSyncManager"
+import { SyncLedger, type Changes } from "./syncLedger"
 
 export type SyncProviderId = "churchApps"
 const getManager = {
@@ -77,7 +78,6 @@ function getMergeGuardKey(data: { id: SyncProviderId; churchId: string; teamId: 
 export async function syncData(data: { id: SyncProviderId; churchId: string; teamId: string; method: "merge" | "read_only" | "upload" | "replace" }) {
     let readOnly = data.method === "read_only" || data.method === "replace" // never write to cloud
     const changedFiles: string[] = [] // WIP write changes
-    deletedNow = []
     let guardCloudModifiedAt = 0
 
     const provider = getManager[data.id]()
@@ -154,6 +154,9 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
         }
     }
     // console.log("Devices:", CHANGES.devices)
+
+    // the ledger owns all created/deleted reconciliation; build it once per run from the resolved state
+    ledger = new SyncLedger({ changes: CHANGES, cloudChanges, deviceId: getDeviceId(), isNewDevice })
 
     // MERGE
     const cloudBibleNames: string[] = []
@@ -318,37 +321,19 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
                 // SYNCED_SETTINGS bundles item-collections (scriptures, categories, styles…) plus a
                 // few atomic settings. Merge the collections per-item via the ledger (like PROJECTS),
                 // so items unique to either device survive and deletions propagate. See #3335.
+                // The per-item logic lives in the pure, unit-tested SyncLedger module (syncLedger.ts).
                 const cloudFileIsNewer = isNewDevice || (await isCloudNewerThanFile(localStore.path, modifiedDates[file.name]))
-                await Promise.all(
-                    Object.entries<{ [key: string]: any }>(cloudFileData).map(async ([type, object]) => {
-                        const isCollection = SYNCED_SETTINGS_COLLECTIONS.includes(type) && !!object && typeof object === "object" && !Array.isArray(object)
-                        if (!isCollection) {
-                            // atomic setting (e.g. drawSettings): keep newest-file-wins
-                            if (cloudFileIsNewer) localData[type] = object
-                            return
-                        }
+                for (const [type, object] of Object.entries<{ [key: string]: any }>(cloudFileData)) {
+                    const isCollection = SYNCED_SETTINGS_COLLECTIONS.includes(type) && !!object && typeof object === "object" && !Array.isArray(object)
+                    if (!isCollection) {
+                        // atomic setting (e.g. drawSettings): keep newest-file-wins
+                        if (cloudFileIsNewer) localData[type] = object
+                        continue
+                    }
 
-                        if (!localData[type] || typeof localData[type] !== "object") localData[type] = {}
-
-                        await Promise.all(
-                            Object.entries(object).map(async ([key, value]) => {
-                                const getLocalData = () => localData[type][key]
-                                // items have no per-item "modified" → resolve by the ledger (requireModifiedTime = false)
-                                const result = await checkCloudEntry(id, `${type}/${key}`, value, getLocalData, undefined, false)
-
-                                if (result.action === "delete") delete localData[type][key]
-                                else if (result.action === "create" || result.action === "download") localData[type][key] = value
-                            })
-                        )
-
-                        // check any local item not in cloud
-                        const localKeys = getLocalOnlyKeys(object, localData[type])
-                        for (const key of localKeys) {
-                            const result = checkLocalEntry(id, `${type}/${key}`)
-                            if (result.action === "delete") delete localData[type][key]
-                        }
-                    })
-                )
+                    if (!localData[type] || typeof localData[type] !== "object") localData[type] = {}
+                    localData[type] = ledger.mergeCollection(id, type, object, localData[type])
+                }
             } else {
                 // promises not needed here, but keeps the code consistent
                 await Promise.all(
@@ -564,53 +549,27 @@ async function deleteUnusedZips(folderPath: string, excludeZip: string) {
     }
 }
 
-async function checkCloudEntry(id: ChangeId, key: string, cloudData: any, getLocalData: () => Promise<any> | any, isCloudNewer?: () => Promise<boolean>, requireModifiedTime = true) {
+async function checkCloudEntry(id: ChangeId, key: string, cloudData: any, getLocalData: () => Promise<any> | any, isCloudNewer?: () => Promise<boolean>) {
     const cloudModTime = getModifiedDate(cloudData)
-    // some collections (e.g. SYNCED_SETTINGS items) have no per-item "modified" → don't treat that
-    // as invalid; fall back to the created/deleted ledger to decide.
-    if (requireModifiedTime && cloudData !== null && !cloudModTime) return { action: "skip" } // invalid: no modified time
+    // entries here are expected to carry a per-item "modified" time; without one the cloud copy is
+    // invalid → skip. (Item-collections with no per-item "modified" are merged via ledger.mergeCollection.)
+    if (cloudData !== null && !cloudModTime) return { action: "skip" } // invalid: no modified time
 
     const localValue = await getLocalData()
 
-    // exists only in cloud
-    if (!localValue) {
-        if (isNewDevice) return { action: "create" }
+    // exists only in cloud → the ledger decides (create / skip)
+    if (!localValue) return ledger.resolveCloudEntry(id, key, false)
 
-        if (isCreated(id, key) && isCreatedLocally(id, key)) {
-            // mark as deleted when it has previously been created, but is now missing
-            markAsDeleted(id, key)
-            return { action: "skip" } // already deleted
-        }
-
-        // if marked as created and not yet created locally
-        if (isCreated(id, key)) {
-            markAsCreated(id, key)
-            return { action: "create" }
-        }
-
-        if (isDeleted(id, key)) {
-            markAsDeleted(id, key)
-            return { action: "skip" } // already deleted
-        }
-
-        markAsDeleted(id, key)
-        return { action: "skip" } // deleted locally
-    }
-
-    if (isDeleted(id, key) && !isNewDevice) {
-        markAsDeleted(id, key)
-        return { action: "delete" }
-    }
-    if (isCreated(id, key)) markAsCreated(id, key) // just in case it's marked as created when it already exists
+    // exists both locally and in cloud → the ledger decides delete/keep; "upload" means keep local,
+    // so break the tie by modified time (newest wins)
+    const decision = ledger.resolveCloudEntry(id, key, true)
+    if (decision.action !== "upload") return decision
 
     let localModTime = getModifiedDate(localValue)
-    if (requireModifiedTime && cloudData !== null && !localModTime) localModTime = setModifiedDate()
+    if (cloudData !== null && !localModTime) localModTime = setModifiedDate()
 
-    // exists both locally and in cloud
     const cloudIsNewer = isCloudNewer ? await isCloudNewer() : cloudModTime > localModTime
-    if (cloudIsNewer) return { action: "download" }
-
-    return { action: "upload" }
+    return { action: cloudIsNewer ? "download" : "upload" }
 
     function getModifiedDate(data: any): number {
         if (!data) return 0
@@ -629,27 +588,9 @@ async function checkCloudEntry(id: ChangeId, key: string, cloudData: any, getLoc
     }
 }
 
-// exists only locally
+// exists only locally → the ledger decides (upload / delete / revive)
 function checkLocalEntry(id: ChangeId, key: string) {
-    if (isNewDevice) return { action: "upload" }
-
-    // marked as deleted in general
-    if (isDeleted(id, key)) {
-        // marked as already deleted for this device
-        if (isDeletedLocally(id, key)) {
-            // revert deletion when local file is restored
-            markAsCreated(id, key)
-            return { action: "upload" }
-        }
-
-        // delete local file/instance
-        markAsDeleted(id, key)
-        return { action: "delete" }
-    }
-
-    // mark as created, for other devices to download
-    markAsCreated(id, key)
-    return { action: "upload" }
+    return ledger.resolveLocalEntry(id, key)
 }
 
 // SYNC LOGIC
@@ -661,13 +602,18 @@ function checkLocalEntry(id: ChangeId, key: string) {
 // if found locally and in cloud: use newest version
 // if marked as deleted locally in cloud, but exists locally: unmark as deleted and mark as created
 
-type Changes = { version: string; devices: string[]; modified: { [key: string]: number }; deleted: { [key: string]: string[] }; created: { [key: string]: string[] } }
 const changes_name = "changes.json"
 const version = "0.1.1"
 const DEFAULT_CHANGES: Changes = { version, devices: [], modified: {}, deleted: {}, created: {} }
 let CHANGES: Changes = clone(DEFAULT_CHANGES)
 let cloudChanges: Changes | null = null
 let isNewDevice = false
+
+// the per-item created/deleted ledger lives in the pure, unit-tested SyncLedger module (syncLedger.ts).
+// it's rebuilt once per sync run (see syncData), so checkCloudEntry/checkLocalEntry delegate to it.
+let ledger = new SyncLedger({ changes: CHANGES, deviceId: "" })
+
+type ChangeId = keyof typeof _store | "SHOWS_CONTENT" | "BIBLES"
 
 // keep track of last changed time so we can know which devices to ignore eventually
 function getLatestChanges() {
@@ -677,87 +623,10 @@ function getLatestChanges() {
     return CHANGES
 }
 
-function getInstanceId(storeId: ChangeId, key: string) {
-    return `${storeId}_${key}`
-}
-
-type ChangeId = keyof typeof _store | "SHOWS_CONTENT" | "BIBLES"
-let deletedNow: string[] = []
-function markAsDeleted(storeId: ChangeId, key: string) {
-    const instanceId = getInstanceId(storeId, key)
-    unmarkAsCreated(storeId, key)
-    markAs("deleted", instanceId)
-    deletedNow.push(instanceId)
-}
-
-function markAsCreated(storeId: ChangeId, key: string) {
-    const instanceId = getInstanceId(storeId, key)
-    unmarkAsDeleted(storeId, key)
-    markAs("created", instanceId)
-}
-
 let _deviceId = ""
 function getDeviceId() {
     if (!_deviceId) _deviceId = getMachineId()
     return _deviceId
-}
-
-function markAs(type: "deleted" | "created", instanceId: string) {
-    // if just one device, no need to keep track of changes
-    if (CHANGES.devices.length < 2) return
-
-    // init
-    if (!CHANGES[type]) CHANGES[type] = {}
-    if (!CHANGES[type][instanceId]) CHANGES[type][instanceId] = []
-
-    const deviceId = getDeviceId()
-
-    // already marked for this device
-    if (CHANGES[type][instanceId].includes(deviceId)) return
-
-    CHANGES[type][instanceId].push(deviceId)
-
-    // remove entry if all devices have the instance
-    if (CHANGES[type][instanceId].length >= CHANGES.devices.length) {
-        delete CHANGES[type][instanceId]
-    }
-}
-
-function unmarkAsDeleted(storeId: ChangeId, key: string) {
-    if (!CHANGES.deleted) return
-
-    const instanceId = getInstanceId(storeId, key)
-    delete CHANGES.deleted[instanceId]
-}
-
-function unmarkAsCreated(storeId: ChangeId, key: string) {
-    if (!CHANGES.created) return
-
-    const instanceId = getInstanceId(storeId, key)
-    delete CHANGES.created[instanceId]
-}
-
-function isDeleted(storeId: ChangeId, key: string): boolean {
-    const instanceId = getInstanceId(storeId, key)
-    return !!CHANGES.deleted?.[instanceId]
-}
-
-function isCreated(storeId: ChangeId, key: string): boolean {
-    const instanceId = getInstanceId(storeId, key)
-    return !!CHANGES.created?.[instanceId]
-}
-
-function isDeletedLocally(storeId: ChangeId, key: string): boolean {
-    const instanceId = getInstanceId(storeId, key)
-    if (deletedNow.includes(instanceId)) return false
-    const deviceId = getDeviceId()
-    return !!cloudChanges?.deleted?.[instanceId]?.includes(deviceId)
-}
-
-function isCreatedLocally(storeId: ChangeId, key: string): boolean {
-    const instanceId = getInstanceId(storeId, key)
-    const deviceId = getDeviceId()
-    return !!cloudChanges?.created?.[instanceId]?.includes(deviceId)
 }
 
 export function markAsNewSync() {

--- a/src/electron/tsconfig.json
+++ b/src/electron/tsconfig.json
@@ -24,5 +24,5 @@
         "skipLibCheck": true
     },
     "include": ["."],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "**/*.test.ts"]
 }


### PR DESCRIPTION
Follow-up to #3354 (the fix) — adds unit tests for the per-item `SYNCED_SETTINGS` merge.

It extracts the per-item ledger decision logic from `syncManager` into a small **pure, dependency-free module** (`SyncLedger`) — no module globals, no I/O — and `syncManager` delegates the `SYNCED_SETTINGS` collection merge to it. Then adds **vitest** with **14 unit tests**, including a **regression test that reproduces #3335** (whole-file overwrite drops the other device's items; the per-item merge keeps them).

Run with `npm run test:unit`.

Opened as a **draft** because it adds vitest as a dev dependency — I asked in #3335 whether unit tests / vitest are welcome. Totally happy to adapt the setup (or drop it) to whatever you prefer.

Note: stacked on #3354. Until that merges, the diff here also includes the fix commit; once #3354 lands on `dev` this will show only the tests + refactor.
