### PR TITLE
Fix Spotify controller on Linux (controls, seek, progress bar)

### DIFF
--- a/src/electron/utils/spotify.ts
+++ b/src/electron/utils/spotify.ts
@@ -126,7 +126,7 @@ export async function getSpotifyState(): Promise<SpotifyState | null> {
                     const artist = out.match(/string\s+"xesam:artist"\s+variant\s+array\s+\[\s+string\s+"([^"]+)"/)?.[1]
                     const len = parseInt(out.match(/string\s+"mpris:length"\s+variant\s+uint64\s+(\d+)/)?.[1] || "0")
                     const art = out.match(/string\s+"mpris:artUrl"\s+variant\s+string\s+"([^"]+)"/)?.[1]
-                    const pos = parseInt(out.match(/uint64\s+(\d+)/)?.[1] || "0")
+                    const pos = parseInt(out.match(/\bint64\s+(\d+)/)?.[1] || "0")
                     const vol = parseFloat(out.match(/double\s+([\d.]+)/)?.[1] || "1")
                     res(title ? { isPlaying: out.includes("Playing"), title, artist: artist || "Unknown", positionSec: pos / 1000000, durationSec: len / 1000000, albumArt: art, volume: vol, platform: "linux" } : null)
                 })
@@ -151,7 +151,7 @@ export async function executeSpotifyCommand(cmd: string, val?: number): Promise<
             const dest = "--dest=org.mpris.MediaPlayer2.spotify /org/mpris/MediaPlayer2"
             const mpris = "org.mpris.MediaPlayer2.Player"
             const run = (c: string) =>
-                exec(`dbus-send ${dest} ${c}`, (e) => {
+                exec(`dbus-send --type=method_call ${dest} ${c}`, (e) => {
                     if (e) {
                         const isServiceUnknown = e.message?.includes("org.freedesktop.DBus.Error.ServiceUnknown") || e.message?.includes("ServiceUnknown")
                         if (!isServiceUnknown) console.error("[Spotify] Linux command error:", e)
@@ -170,7 +170,7 @@ export async function executeSpotifyCommand(cmd: string, val?: number): Promise<
                         return
                     }
                     const id = out?.match(/string\s+"mpris:trackid"\s+variant\s+string\s+"([^"]+)"/)?.[1]
-                    if (id) run(`${mpris}.SetPosition objpath:${id} x64:${Math.round(val * 1000000)}`)
+                    if (id) run(`${mpris}.SetPosition objpath:${id} int64:${Math.round(val * 1000000)}`)
                 })
             }
         }


### PR DESCRIPTION
Fixes the Spotify controller on Linux. All three issues are in the `dbus-send` usage in `src/electron/utils/spotify.ts`:

1. **Controls did nothing** — commands were sent via `dbus-send` without `--type=method_call`. `dbus-send` defaults to `signal` (per its man page), which the player ignores (exit code 0, no effect). Reading state worked only because it uses `--print-reply`, which implies `method_call`. → added `--type=method_call`.
2. **Seek errored** — `SetPosition` used `x64:` as the argument type, which isn't a valid `dbus-send` type name (`x` is the D-Bus signature code; the `dbus-send` name is `int64`), failing with `dbus-send: Unknown type "x64"`. → changed to `int64:`.
3. **Progress bar stuck at 100%** — position was parsed with `/uint64\s+(\d+)/`, which matched `mpris:length` (the first `uint64` = duration) instead of `Position`, so `positionSec === durationSec`. Also, the MPRIS `Position` property is `int64`, not `uint64`. → changed to `/\bint64\s+(\d+)/`.

Tested on Ubuntu 26.04 and 25.10 (GNOME/Wayland, native Spotify client): play/pause, next/previous, seeking and the progress bar all work now.

Closes #3356. Opening as draft until the bug is confirmed.
