### PR TITLE
Fix Windows output visibility during Aero Peek

### DIFF
--- a/src/electron/output/helpers/OutputAlwaysOnTop.ts
+++ b/src/electron/output/helpers/OutputAlwaysOnTop.ts
@@ -1,0 +1,66 @@
+import { execFile } from "child_process"
+import type { BrowserWindow } from "electron"
+
+const OUTPUT_ALWAYS_ON_TOP_LEVEL = process.platform === "win32" ? "screen-saver" : "pop-up-menu"
+const DWMWA_DISALLOW_PEEK = 11
+const DWMWA_EXCLUDED_FROM_PEEK = 12
+const DWM_PEEK_ATTRIBUTES = [DWMWA_DISALLOW_PEEK, DWMWA_EXCLUDED_FROM_PEEK]
+const DWM_PEEK_SCRIPT = `
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+
+public static class FreeShowDwm {
+    [DllImport("dwmapi.dll")]
+    public static extern int DwmSetWindowAttribute(IntPtr hwnd, int dwAttribute, ref int pvAttribute, int cbAttribute);
+}
+"@
+
+function Set-FreeShowDwmAttributes {
+    param(
+        [Int64]$HwndValue,
+        [Int32]$Enabled,
+        [Int32[]]$Attributes
+    )
+
+    $hwnd = [IntPtr]::new($HwndValue)
+
+    foreach ($attribute in $Attributes) {
+        $result = [FreeShowDwm]::DwmSetWindowAttribute($hwnd, $attribute, [ref]$Enabled, 4)
+        if ($result -ne 0) {
+            exit $result
+        }
+    }
+}
+`
+
+export function setOutputAlwaysOnTop(window: BrowserWindow, value: boolean) {
+    window.setAlwaysOnTop(value, OUTPUT_ALWAYS_ON_TOP_LEVEL, 1)
+    setExcludedFromAeroPeek(window, value)
+}
+
+function setExcludedFromAeroPeek(window: BrowserWindow, value: boolean) {
+    if (process.platform !== "win32") return
+
+    const hwnd = getWindowHandle(window)
+    if (!hwnd) return
+
+    const enabled = value ? 1 : 0
+    const attributes = DWM_PEEK_ATTRIBUTES.join(",")
+    const command = [DWM_PEEK_SCRIPT, `Set-FreeShowDwmAttributes -HwndValue ${hwnd} -Enabled ${enabled} -Attributes ${attributes}`].join("\n")
+    const encodedCommand = Buffer.from(command, "utf16le").toString("base64")
+    const args = ["-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", encodedCommand]
+
+    execFile("powershell.exe", args, { windowsHide: true }, (error) => {
+        if (error) console.warn("Could not update output Aero Peek visibility:", error.message)
+    })
+}
+
+function getWindowHandle(window: BrowserWindow) {
+    const handle = window.getNativeWindowHandle()
+
+    if (handle.length >= 8) return handle.readBigUInt64LE(0).toString()
+    if (handle.length >= 4) return handle.readUInt32LE(0).toString()
+
+    return ""
+}

--- a/src/electron/output/helpers/OutputAlwaysOnTop.ts
+++ b/src/electron/output/helpers/OutputAlwaysOnTop.ts
@@ -2,65 +2,37 @@ import { execFile } from "child_process"
 import type { BrowserWindow } from "electron"
 
 const OUTPUT_ALWAYS_ON_TOP_LEVEL = process.platform === "win32" ? "screen-saver" : "pop-up-menu"
-const DWMWA_DISALLOW_PEEK = 11
-const DWMWA_EXCLUDED_FROM_PEEK = 12
-const DWM_PEEK_ATTRIBUTES = [DWMWA_DISALLOW_PEEK, DWMWA_EXCLUDED_FROM_PEEK]
-const DWM_PEEK_SCRIPT = `
-Add-Type @"
-using System;
-using System.Runtime.InteropServices;
-
-public static class FreeShowDwm {
-    [DllImport("dwmapi.dll")]
-    public static extern int DwmSetWindowAttribute(IntPtr hwnd, int dwAttribute, ref int pvAttribute, int cbAttribute);
-}
-"@
-
-function Set-FreeShowDwmAttributes {
-    param(
-        [Int64]$HwndValue,
-        [Int32]$Enabled,
-        [Int32[]]$Attributes
-    )
-
-    $hwnd = [IntPtr]::new($HwndValue)
-
-    foreach ($attribute in $Attributes) {
-        $result = [FreeShowDwm]::DwmSetWindowAttribute($hwnd, $attribute, [ref]$Enabled, 4)
-        if ($result -ne 0) {
-            exit $result
-        }
-    }
-}
-`
 
 export function setOutputAlwaysOnTop(window: BrowserWindow, value: boolean) {
-    window.setAlwaysOnTop(value, OUTPUT_ALWAYS_ON_TOP_LEVEL, 1)
-    setExcludedFromAeroPeek(window, value)
+    if (window.isDestroyed()) return
+
+    try {
+        window.setAlwaysOnTop(value, OUTPUT_ALWAYS_ON_TOP_LEVEL, 1)
+
+        if (process.platform === "win32") {
+            const handle = window.getNativeWindowHandle()
+            setExcludedFromAeroPeek(handle, value)
+        }
+    } catch (err) {
+        console.warn("Failed to set always on top:", err)
+    }
 }
 
-function setExcludedFromAeroPeek(window: BrowserWindow, value: boolean) {
-    if (process.platform !== "win32") return
+// Windows only: use DWM to exclude the window from "Aero Peek"
+// this prevents the output from being hidden when the user peeks at the taskbar
+function setExcludedFromAeroPeek(handle: Buffer, state: boolean) {
+    const hwnd = (handle.length === 8 ? handle.readBigUInt64LE(0) : handle.readUInt32LE(0)).toString()
+    const enabled = state ? 1 : 0
 
-    const hwnd = getWindowHandle(window)
-    if (!hwnd) return
-
-    const enabled = value ? 1 : 0
-    const attributes = DWM_PEEK_ATTRIBUTES.join(",")
-    const command = [DWM_PEEK_SCRIPT, `Set-FreeShowDwmAttributes -HwndValue ${hwnd} -Enabled ${enabled} -Attributes ${attributes}`].join("\n")
+    // PowerShell script to call DwmSetWindowAttribute
+    const command = `
+        $t = Add-Type -MemberDefinition '[DllImport("dwmapi.dll")]public static extern int DwmSetWindowAttribute(IntPtr h,int a,ref int v,int s);' -Name "Dwm${hwnd}" -PassThru
+        [int]$v = ${enabled}
+        11,12 | ForEach-Object { $t::DwmSetWindowAttribute([IntPtr]${hwnd}, $_, [ref]$v, 4) }
+    `
     const encodedCommand = Buffer.from(command, "utf16le").toString("base64")
-    const args = ["-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", encodedCommand]
 
-    execFile("powershell.exe", args, { windowsHide: true }, (error) => {
-        if (error) console.warn("Could not update output Aero Peek visibility:", error.message)
+    execFile("powershell.exe", ["-NoProfile", "-NonInteractive", "-WindowStyle", "Hidden", "-EncodedCommand", encodedCommand], { windowsHide: true }, (error) => {
+        if (error) console.warn("Could not update output Aero Peek visibility:", error)
     })
-}
-
-function getWindowHandle(window: BrowserWindow) {
-    const handle = window.getNativeWindowHandle()
-
-    if (handle.length >= 8) return handle.readBigUInt64LE(0).toString()
-    if (handle.length >= 4) return handle.readUInt32LE(0).toString()
-
-    return ""
 }

--- a/src/electron/output/helpers/OutputLifecycle.ts
+++ b/src/electron/output/helpers/OutputLifecycle.ts
@@ -8,6 +8,7 @@ import { setDataNDI } from "../../ndi/talk"
 import { wait } from "../../utils/helpers"
 import { outputOptions } from "../../utils/windowOptions"
 import { OutputHelper } from "../OutputHelper"
+import { setOutputAlwaysOnTop } from "./OutputAlwaysOnTop"
 import { OutputVisibility } from "./OutputVisibility"
 import { initializeSender } from "../../blackmagic/bmdTalk"
 import { BlackmagicSender } from "../../blackmagic/BlackmagicSender"
@@ -112,7 +113,7 @@ export class OutputLifecycle {
         if (isMac) window.minimize() // hide on mac
 
         window.once("show", () => {
-            if (options.alwaysOnTop) window?.setAlwaysOnTop(true, "pop-up-menu", 1)
+            if (options.alwaysOnTop) setOutputAlwaysOnTop(window, true)
         })
         // window.setVisibleOnAllWorkspaces(true)
 

--- a/src/electron/output/helpers/OutputValues.ts
+++ b/src/electron/output/helpers/OutputValues.ts
@@ -5,6 +5,7 @@ import { NdiSender } from "../../ndi/NdiSender"
 import type { Output as OutputWindow } from "../Output"
 import { OutputHelper } from "../OutputHelper"
 import type { Output } from "../../../types/Output"
+import { setOutputAlwaysOnTop } from "./OutputAlwaysOnTop"
 
 const setValues = {
     ndi: async (value: boolean, window: BrowserWindow, id: string) => {
@@ -32,7 +33,7 @@ const setValues = {
         output.transparent = value
     },
     alwaysOnTop: (value: boolean, window: BrowserWindow, _id: string, output: OutputWindow) => {
-        window.setAlwaysOnTop(value, "pop-up-menu", 1)
+        setOutputAlwaysOnTop(window, value)
         // show in taskbar if not always on top, because this will also show it in Alt+Tab menu
         window.setSkipTaskbar(value)
         if (output.boundsLocked !== true) window.setResizable(!value)

--- a/src/electron/output/helpers/OutputVisibility.ts
+++ b/src/electron/output/helpers/OutputVisibility.ts
@@ -4,6 +4,7 @@ import { mainWindow, toApp } from "../.."
 import { MAIN, OUTPUT } from "../../../types/Channels"
 import type { Output } from "../../../types/Output"
 import { OutputHelper } from "../OutputHelper"
+import { setOutputAlwaysOnTop } from "./OutputAlwaysOnTop"
 import { OutputBounds } from "./OutputBounds"
 
 export class OutputVisibility {
@@ -43,7 +44,7 @@ export class OutputVisibility {
         const windowNotCoveringMain = this.amountCovered(bounds, mainWindow!.getBounds()) < 0.5
 
         if (state === true && (force || window.isAlwaysOnTop() === false || windowNotCoveringMain)) {
-            this.showWindow(window)
+            this.showWindow(window, output.alwaysOnTop !== false)
 
             OutputHelper.Bounds.updateBounds({ id: output.id, bounds })
             return true
@@ -95,10 +96,11 @@ export class OutputVisibility {
     // https://github.com/electron/electron/issues/1415
     // https://github.com/electron/electron/issues/1054
 
-    static showWindow(window: BrowserWindow) {
+    static showWindow(window: BrowserWindow, alwaysOnTop = true) {
         if (!window || window.isDestroyed()) return
 
         window.showInactive()
+        if (alwaysOnTop) setOutputAlwaysOnTop(window, true)
         window.moveTop()
     }
 


### PR DESCRIPTION
Lots of PR's this week but I'm fine if this one gets closed, more so to give you an idea.

Currently, even with always on top enabled, the output gets interrupted during Aero Peak (when I hover on an app in the taskbar). This gets annoying especially when I have multiple windows of an app open, as hovering on any one of them makes all outputs go to the background which gets distracting. I tried screensaver method, but it seems that aero peak is implemented at a lower level, so this uses a hacky PowerShell method.

Would be great if this could be fixed, but there might be a better fix.

https://syobochim.medium.com/electron-keep-apps-on-top-whether-in-full-screen-mode-or-on-other-desktops-d7d914579fce
