### PR TITLE
test(sync): cover the modified-time merge path for shows/projects/stage

### DIFF
--- a/src/electron/cloud/syncLedger.test.ts
+++ b/src/electron/cloud/syncLedger.test.ts
@@ -52,12 +52,37 @@ describe("SyncLedger — per-item merge (#3335)", () => {
 
             expect(b.resolveCloudEntry(ID, KEY, /* localExists */ false).action).toBe("skip")
         })
+    })
 
-        it("an item that exists on both sides and is not deleted is kept (upload) for the caller to tie-break by date", () => {
+    describe("entries with a per-item modified time (shows / projects / stage — newest wins)", () => {
+        // these stores carry a per-item "modified"; checkCloudEntry computes cloudIsNewer and passes it here
+        it("downloads when the cloud copy is newer", () => {
             const changes = makeChanges(["A", "B"])
             const b = new SyncLedger({ changes, deviceId: "B" })
 
-            expect(b.resolveCloudEntry(ID, KEY, /* localExists */ true).action).toBe("upload")
+            expect(b.resolveCloudEntry("SHOWS_CONTENT", "show1", /* localExists */ true, /* cloudIsNewer */ true).action).toBe("download")
+        })
+
+        it("keeps the local copy (upload) when it is not older than the cloud", () => {
+            const changes = makeChanges(["A", "B"])
+            const b = new SyncLedger({ changes, deviceId: "B" })
+
+            expect(b.resolveCloudEntry("PROJECTS", "proj1", /* localExists */ true, /* cloudIsNewer */ false).action).toBe("upload")
+        })
+
+        it("a tombstoned item is deleted regardless of the date (the ledger wins over newest)", () => {
+            const changes = makeChanges(["A", "B"], { deleted: { STAGE_stage1: ["A"] } })
+            const b = new SyncLedger({ changes, deviceId: "B" })
+
+            // even with a newer cloud copy, a deleted item is removed, not downloaded
+            expect(b.resolveCloudEntry("STAGE", "stage1", /* localExists */ true, /* cloudIsNewer */ true).action).toBe("delete")
+        })
+
+        it("a brand-new device downloads the newer cloud copy and ignores tombstones", () => {
+            const changes = makeChanges(["A", "B"], { deleted: { SHOWS_CONTENT_show1: ["A"] } })
+            const fresh = new SyncLedger({ changes, deviceId: "C", isNewDevice: true })
+
+            expect(fresh.resolveCloudEntry("SHOWS_CONTENT", "show1", /* localExists */ true, /* cloudIsNewer */ true).action).toBe("download")
         })
     })
 

--- a/src/electron/cloud/syncLedger.ts
+++ b/src/electron/cloud/syncLedger.ts
@@ -108,11 +108,12 @@ export class SyncLedger {
 
     // ----- merge decisions (item-collections with no per-item "modified") -----
 
-    // Item present in the cloud snapshot; decide create/skip/delete/keep given whether it exists locally.
-    // Single source of truth for the ledger decision: syncManager.checkCloudEntry delegates here.
-    // An "upload" result means "keep local for now" — for entries that carry a per-item "modified",
-    // the caller then breaks the tie by date (download if the cloud copy is newer).
-    resolveCloudEntry(storeId: string, key: string, localExists: boolean): { action: EntryAction } {
+    // Item present in the cloud snapshot; decide create/skip/delete/download/upload given whether it
+    // exists locally. Single source of truth for the cloud-side decision: syncManager.checkCloudEntry
+    // delegates here. When the item exists on both sides and the ledger doesn't force delete, the
+    // newest copy wins: entries that carry a per-item "modified" pass `cloudIsNewer` (shows, projects,
+    // stage, …); item-collections have no per-item "modified" and omit it → keep local (upload).
+    resolveCloudEntry(storeId: string, key: string, localExists: boolean, cloudIsNewer = false): { action: EntryAction } {
         // exists only in cloud
         if (!localExists) {
             if (this.isNewDevice) return { action: "create" }
@@ -142,9 +143,8 @@ export class SyncLedger {
         }
         if (this.isCreated(storeId, key)) this.markAsCreated(storeId, key)
 
-        // exists on both sides and not deleted → keep local; the caller may override to "download"
-        // by modified time (collections have no per-item "modified", so they stay as upload)
-        return { action: "upload" }
+        // exists on both sides and not deleted → newest wins (collections pass cloudIsNewer=false → keep local)
+        return { action: cloudIsNewer ? "download" : "upload" }
     }
 
     // Item present only locally (not in the cloud snapshot).

--- a/src/electron/cloud/syncManager.ts
+++ b/src/electron/cloud/syncManager.ts
@@ -560,16 +560,13 @@ async function checkCloudEntry(id: ChangeId, key: string, cloudData: any, getLoc
     // exists only in cloud → the ledger decides (create / skip)
     if (!localValue) return ledger.resolveCloudEntry(id, key, false)
 
-    // exists both locally and in cloud → the ledger decides delete/keep; "upload" means keep local,
-    // so break the tie by modified time (newest wins)
-    const decision = ledger.resolveCloudEntry(id, key, true)
-    if (decision.action !== "upload") return decision
-
+    // exists both locally and in cloud → resolve the tie by modified time (newest wins) and let the
+    // ledger apply it — it still forces delete/skip first if the item is marked deleted/created.
     let localModTime = getModifiedDate(localValue)
     if (cloudData !== null && !localModTime) localModTime = setModifiedDate()
 
     const cloudIsNewer = isCloudNewer ? await isCloudNewer() : cloudModTime > localModTime
-    return { action: cloudIsNewer ? "download" : "upload" }
+    return ledger.resolveCloudEntry(id, key, true, cloudIsNewer)
 
     function getModifiedDate(data: any): number {
         if (!data) return 0


### PR DESCRIPTION
Small follow-up to #3355 — adds the unit tests @vassbo asked about: the shows/projects/stage path (and bibles), which resolve by "newest `modified` wins" when an item exists on both sides.

To make that path unit-testable, the date tie-break now lives in the pure `SyncLedger.resolveCloudEntry` (it takes a `cloudIsNewer` flag); `checkCloudEntry` computes the date and delegates. Item-collections are unaffected (no flag → keep local).

4 new tests: cloud newer → download, local newer → keep, a tombstoned item is deleted regardless of date, a new device downloads and ignores tombstones. `npm run test:unit` → 18 passed · `tsc` clean.
