### PR TITLE
Add chord image (Akkordogramm) feature with NDI output selection

### DIFF
--- a/src/frontend/components/helpers/showActions.ts
+++ b/src/frontend/components/helpers/showActions.ts
@@ -307,21 +307,18 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
                 }
             })
         }
-// AKKORDOGRAMM - send chord image to NDI output if set
+// AKKORDOGRAMM - send chord image to selected output
 const chordImage = _show(showId).get("metadata")?.chordImage
-if (chordImage) {
-    const allOutputs = get(outputs)
-    const chordOutputId = Object.keys(allOutputs).find((id) => allOutputs[id]?.name?.toLowerCase().includes("ndi") || allOutputs[id]?.name?.toLowerCase().includes("akkord"))
-    if (chordOutputId) {
-        setOutput("background", {
-            name: "Akkordogramm",
-            type: "image",
-            path: chordImage,
-            loop: false,
-            muted: true,
-            fit: "contain"
-        }, false, chordOutputId)
-    }
+const chordOutputId = _show(showId).get("metadata")?.chordOutputId
+if (chordImage && chordOutputId && get(outputs)[chordOutputId]) {
+    setOutput("background", {
+        name: "Akkordogramm",
+        type: "image",
+        path: chordImage,
+        loop: false,
+        muted: true,
+        fit: "contain"
+    }, false, chordOutputId)
 }
         // nextTimer - start next slide timer immediately before any awaits
         nextSlideTimers(outputId)

--- a/src/frontend/components/helpers/showActions.ts
+++ b/src/frontend/components/helpers/showActions.ts
@@ -307,7 +307,22 @@ export function updateOut(showId: string, index: number, layout: LayoutRef[], ex
                 }
             })
         }
-
+// AKKORDOGRAMM - send chord image to NDI output if set
+const chordImage = _show(showId).get("metadata")?.chordImage
+if (chordImage) {
+    const allOutputs = get(outputs)
+    const chordOutputId = Object.keys(allOutputs).find((id) => allOutputs[id]?.name?.toLowerCase().includes("ndi") || allOutputs[id]?.name?.toLowerCase().includes("akkord"))
+    if (chordOutputId) {
+        setOutput("background", {
+            name: "Akkordogramm",
+            type: "image",
+            path: chordImage,
+            loop: false,
+            muted: true,
+            fit: "contain"
+        }, false, chordOutputId)
+    }
+}
         // nextTimer - start next slide timer immediately before any awaits
         nextSlideTimers(outputId)
 

--- a/src/frontend/components/show/tools/Metadata.svelte
+++ b/src/frontend/components/show/tools/Metadata.svelte
@@ -5,11 +5,13 @@
     import { history } from "../../helpers/history"
     import { getCustomMetadata, initializeMetadata } from "../../helpers/show"
     import MaterialTextInput from "../../inputs/MaterialTextInput.svelte"
+    import MaterialFilePicker from "../../inputs/MaterialFilePicker.svelte"
     import Tip from "../../main/Tip.svelte"
     import MaterialNumberInput from "../../inputs/MaterialNumberInput.svelte"
 
     $: currentShow = $showsCache[$activeShow!.id]
     $: meta = currentShow.meta
+    $: chordImage = currentShow?.metadata?.chordImage || ""
     let values: { [key: string]: string } = {}
 
     onMount(getValues)
@@ -27,10 +29,6 @@
         })
     }
 
-    // duration = quickaccess only
-    // number = quickaccess & metadata
-    // CCLI = quickaccess (metadata) & metadata
-    // others = metadata only
     const changeValue = (value: string, key: string) => {
         if (key === "duration") {
             setQuickAccess(key, value)
@@ -69,13 +67,13 @@
         history({ id: "UPDATE", newData: { data, key }, oldData: { id: $activeShow?.id || "" }, location: { page: "show", id: "show_key", override } })
     }
 
-    // AUTOFILL
-
     const autofillValues = {
-        // get only numbers at the start or end
         number: () => values.number || currentShow.name?.match(/^\d+/)?.[0] || currentShow.name?.match(/\d+$/)?.[0],
-        // remove numbers
         title: () => (currentShow.name || "").replace(/[0-9\-.,!:;]/g, "").trim()
+    }
+
+    function setChordImage(path: string) {
+        updateData({ ...(currentShow.metadata || {}), chordImage: path }, "metadata")
     }
 </script>
 
@@ -91,16 +89,22 @@
             <MaterialTextInput {label} style={numberStored ? "border-bottom: 1px solid var(--secondary);" : ""} {value} autofill={autofillValue} on:change={(e) => changeValue(e.detail, key)} />
         {/each}
 
-        <!-- not visible as metadata (only in project) -->
         <MaterialNumberInput label="transition.duration (s)" value={currentShow?.quickAccess?.duration} on:change={(e) => changeValue(e.detail, "duration")} hideWhenZero />
     </div>
 
-    <Tip value="tips.display_metadata" style="margin: 0 10px;" bottom={10} />
+    <div style="padding: 10px; display: flex; flex-direction: column; gap: 8px;">
+        <p style="font-size: 0.85em; opacity: 0.7; margin: 0;">Akkordogramm</p>
+        <MaterialFilePicker
+            label="Akkordogramm auswählen"
+            value={chordImage}
+            filter={{ name: "Bilder", extensions: ["jpg", "jpeg", "png"] }}
+            allowEmpty={true}
+            showThumbnail={!!chordImage}
+            on:change={(e) => setChordImage(e.detail)}
+        />
+    </div>
 
-    <!-- <h5><T id="meta.tags" /></h5>
-    <div class="tags" style="display: flex;flex-direction: column;">
-        <Tags />
-    </div> -->
+    <Tip value="tips.display_metadata" style="margin: 0 10px;" bottom={10} />
 </section>
 
 <style>

--- a/src/frontend/components/show/tools/Metadata.svelte
+++ b/src/frontend/components/show/tools/Metadata.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
     import { onMount } from "svelte"
-    import { activeShow, customMetadata, dictionary, shows, showsCache } from "../../../stores"
+    import { activeShow, customMetadata, dictionary, outputs, shows, showsCache } from "../../../stores"
     import { translateText } from "../../../utils/language"
     import { history } from "../../helpers/history"
     import { getCustomMetadata, initializeMetadata } from "../../helpers/show"
+    import { keysToID, sortByName } from "../../helpers/array"
     import MaterialTextInput from "../../inputs/MaterialTextInput.svelte"
     import MaterialFilePicker from "../../inputs/MaterialFilePicker.svelte"
+    import MaterialDropdown from "../../inputs/MaterialDropdown.svelte"
     import Tip from "../../main/Tip.svelte"
     import MaterialNumberInput from "../../inputs/MaterialNumberInput.svelte"
 
     $: currentShow = $showsCache[$activeShow!.id]
     $: meta = currentShow.meta
     $: chordImage = currentShow?.metadata?.chordImage || ""
+    $: chordOutputId = currentShow?.metadata?.chordOutputId || ""
     let values: { [key: string]: string } = {}
 
     onMount(getValues)
@@ -75,6 +78,12 @@
     function setChordImage(path: string) {
         updateData({ ...(currentShow.metadata || {}), chordImage: path }, "metadata")
     }
+
+    function setChordOutput(outputId: string) {
+        updateData({ ...(currentShow.metadata || {}), chordOutputId: outputId }, "metadata")
+    }
+
+    $: outputOptions = [{ value: "", label: translateText("actions.all_outputs") }, ...sortByName(keysToID($outputs).filter((a) => !a.stageOutput)).map((a) => ({ value: a.id, label: a.name }))]
 </script>
 
 <section>
@@ -92,8 +101,8 @@
         <MaterialNumberInput label="transition.duration (s)" value={currentShow?.quickAccess?.duration} on:change={(e) => changeValue(e.detail, "duration")} hideWhenZero />
     </div>
 
-    <div style="padding: 10px; display: flex; flex-direction: column; gap: 8px;">
-        <p style="font-size: 0.85em; opacity: 0.7; margin: 0;">Akkordogramm</p>
+    <div class="chord-section">
+        <h5>Akkordogramm</h5>
         <MaterialFilePicker
             label="Akkordogramm auswählen"
             value={chordImage}
@@ -102,6 +111,7 @@
             showThumbnail={!!chordImage}
             on:change={(e) => setChordImage(e.detail)}
         />
+        <MaterialDropdown label="Akkorde-Output" options={outputOptions} value={chordOutputId} on:change={(e) => setChordOutput(e.detail)} />
     </div>
 
     <Tip value="tips.display_metadata" style="margin: 0 10px;" bottom={10} />
@@ -115,5 +125,19 @@
 
     section :global(.title) {
         margin: 5px 0;
+    }
+
+    .chord-section {
+        padding: 10px;
+        display: flex;
+        flex-direction: column;
+        gap: 8px;
+    }
+
+    .chord-section h5 {
+        margin: 0 0 4px 0;
+        font-size: 0.85em;
+        opacity: 0.7;
+        font-weight: 500;
     }
 </style>

--- a/src/types/Show.ts
+++ b/src/types/Show.ts
@@ -36,6 +36,7 @@ export interface Show {
         // display: string
         // template: string
         tags?: string[]
+        chordImage?: string // Pfad zum Akkordogramm-JPG
     }
     meta: {
         number?: string


### PR DESCRIPTION
## What does this feature do?

Adds the ability to assign a chordogram image (JPG/PNG) to each song, 
which is automatically sent to a user-selectable output as soon as a slide 
for that song is activated.

## Use Case

Churches/bands that want to display chord diagrams for musicians on a separate monitor (e.g., via NDI) 
without them being visible on the main projector.

## Changes

- New `chordImage` and `chordOutputId` fields in Show Metadata
- UI in the Metadata tab for selecting the image and target output
- Logic in `showActions.ts` to send the image to the selected output when the slide changes