### PR TITLE
test: add unit tests for helpers, utils, and converters

### DIFF
--- a/src/electron/utils/helpers.test.ts
+++ b/src/electron/utils/helpers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from "vitest"
+import { checkIfMatching, clone, wait, waitUntilValueIsDefined } from "./helpers"
+
+describe("clone (electron helper)", () => {
+    it("returns a deep copy — the original is untouched after mutations", () => {
+        const src = { a: { b: [1, 2, 3] } }
+        const copy = clone(src)
+        copy.a.b.push(99)
+        expect(src.a.b).toEqual([1, 2, 3])
+    })
+    it("returns primitives and null as-is", () => {
+        expect(clone(5 as any)).toBe(5)
+        expect(clone("hi" as any)).toBe("hi")
+        expect(clone(null as any)).toBe(null)
+    })
+})
+
+describe("checkIfMatching", () => {
+    it("returns true regardless of key insertion order", () => {
+        expect(checkIfMatching({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+    })
+    it("returns false when a value differs", () => {
+        expect(checkIfMatching({ a: 1 }, { a: 2 })).toBe(false)
+    })
+    it("returns false when either side is falsy or non-object (guards against bad store loads)", () => {
+        expect(checkIfMatching(null, { a: 1 })).toBe(false)
+        expect(checkIfMatching({ a: 1 }, undefined)).toBe(false)
+        expect(checkIfMatching("hi" as any, "hi" as any)).toBe(false)
+    })
+})
+
+describe("wait", () => {
+    it("resolves with 'ended' after roughly the requested delay", async () => {
+        const start = Date.now()
+        const result = await wait(20)
+        expect(result).toBe("ended")
+        // sanity: at least ~10ms elapsed (loose bound: CI schedulers vary)
+        expect(Date.now() - start).toBeGreaterThanOrEqual(10)
+    })
+})
+
+describe("waitUntilValueIsDefined", () => {
+    it("resolves immediately with the value if it's already defined", async () => {
+        const result = await waitUntilValueIsDefined(() => 42, 10, 200)
+        expect(result).toBe(42)
+    })
+
+    it("polls at the given interval until the value becomes truthy", async () => {
+        let attempts = 0
+        const result = await waitUntilValueIsDefined(
+            () => {
+                attempts++
+                return attempts >= 3 ? "ready" : null
+            },
+            10, // 10ms interval
+            500 // 500ms overall timeout
+        )
+        expect(result).toBe("ready")
+        expect(attempts).toBeGreaterThanOrEqual(3)
+    })
+
+    it("resolves null when the timeout elapses without a truthy value", async () => {
+        const result = await waitUntilValueIsDefined(() => null, 10, 50)
+        expect(result).toBeNull()
+    })
+})

--- a/src/frontend/components/helpers/array.test.ts
+++ b/src/frontend/components/helpers/array.test.ts
@@ -1,0 +1,240 @@
+import { describe, it, expect, vi } from "vitest"
+
+// array.ts pulls in ../../utils/language for translateText (used by sortObject); language.ts
+// drags stores + IPC + `window` into scope, none of which we care about here. Stub it out.
+vi.mock("../../utils/language", () => ({
+    translateText: (s: string) => s
+}))
+
+import { arrayHasData, areObjectsEqual, changeValues, clone, getChangedKeys, keysToID, moveToPos, rangeSelect, removeDeleted, removeDuplicates, removeDuplicateValues, removeValues, sortByName, sortByNameAndNumber, sortByTime, sortByTimeNew, sortFilenames, sortObject, sortObjectNumbers } from "./array"
+
+describe("arrayHasData", () => {
+    it("finds a primitive value in the array", () => {
+        expect(arrayHasData([1, 2, 3] as any, 2)).toBe(true)
+    })
+    it("finds a deeply-equal object", () => {
+        expect(arrayHasData([{ a: 1 }, { b: 2 }] as any, { b: 2 })).toBe(true)
+    })
+    it("returns false for a missing value", () => {
+        expect(arrayHasData([1, 2, 3] as any, 4)).toBe(false)
+    })
+    it("returns false for non-array input", () => {
+        expect(arrayHasData("not an array" as any, "n")).toBe(false)
+        expect(arrayHasData(null as any, null)).toBe(false)
+    })
+})
+
+describe("removeDuplicates", () => {
+    it("removes primitive duplicates while preserving first-seen order", () => {
+        expect(removeDuplicates([1, 2, 2, 3, 1] as any)).toEqual([1, 2, 3])
+    })
+    it("does not deep-dedupe objects (identity only, by design of Set)", () => {
+        const a = { x: 1 }
+        expect(removeDuplicates([a, { x: 1 }, a] as any)).toHaveLength(2)
+    })
+    it("returns non-array input unchanged", () => {
+        expect(removeDuplicates("hi" as any)).toBe("hi")
+    })
+})
+
+describe("sortByTime / sortByTimeNew", () => {
+    it("sortByTime compares plain Date-like values", () => {
+        const arr = ["2023-01-02", "2023-01-01", "2023-01-03"]
+        expect([...arr].sort(sortByTime as any)).toEqual(["2023-01-01", "2023-01-02", "2023-01-03"])
+    })
+    it("sortByTime unwraps a `from` field for calendar events", () => {
+        const events = [{ from: "2023-01-02" }, { from: "2023-01-01" }]
+        expect([...events].sort(sortByTime as any)[0].from).toBe("2023-01-01")
+    })
+    it("sortByTimeNew sorts objects by the given key ascending", () => {
+        const arr = [{ time: 300 }, { time: 100 }, { time: 200 }]
+        expect(sortByTimeNew(arr).map((a) => a.time)).toEqual([100, 200, 300])
+    })
+})
+
+describe("moveToPos", () => {
+    it("moves an item to a new index", () => {
+        expect(moveToPos([1, 2, 3, 4] as any, 0, 2)).toEqual([2, 3, 1, 4])
+    })
+    it("pads with undefined when newPos is past the end", () => {
+        const result = moveToPos([1, 2] as any, 0, 3) as any[]
+        expect(result[3]).toBe(1)
+        expect(result.length).toBe(4)
+    })
+    it("returns the array unchanged for a negative newPos", () => {
+        const arr = [1, 2, 3]
+        expect(moveToPos(arr as any, 0, -1)).toBe(arr as any)
+    })
+    it("returns non-array input unchanged", () => {
+        expect(moveToPos("nope" as any, 0, 1)).toBe("nope")
+    })
+})
+
+describe("sortByName", () => {
+    it("sorts by name alphabetically", () => {
+        const arr = [{ name: "Charlie" }, { name: "alpha" }, { name: "Bravo" }]
+        // localeCompare is case-insensitive-ish so 'alpha' < 'Bravo' < 'Charlie'
+        expect(sortByName(arr).map((a) => a.name)).toEqual(["alpha", "Bravo", "Charlie"])
+    })
+    it("treats embedded numbers naturally with numberSort (default)", () => {
+        const arr = [{ name: "Track 10" }, { name: "Track 2" }, { name: "Track 1" }]
+        expect(sortByName(arr).map((a) => a.name)).toEqual(["Track 1", "Track 2", "Track 10"])
+    })
+    it("filters out entries whose sort key isn't a string", () => {
+        const arr = [{ name: "a" }, { name: 42 as unknown as string }, { name: "b" }]
+        expect(sortByName(arr).map((a) => a.name)).toEqual(["a", "b"])
+    })
+    it("returns [] for non-array input (guards against store misuse)", () => {
+        expect(sortByName(undefined as any)).toEqual([])
+    })
+})
+
+describe("sortObject", () => {
+    it("sorts objects by the given key", () => {
+        const arr = [{ label: "c" }, { label: "a" }, { label: "b" }]
+        expect(sortObject(arr, "label" as any).map((a) => a.label)).toEqual(["a", "b", "c"])
+    })
+    it("treats missing keys as empty strings", () => {
+        const arr: any[] = [{ label: "b" }, {}, { label: "a" }]
+        const sorted = sortObject(arr, "label" as any)
+        expect(sorted[0].label).toBeUndefined()
+    })
+})
+
+describe("sortObjectNumbers", () => {
+    it("sorts ascending by numeric key", () => {
+        const arr = [{ n: 3 }, { n: 1 }, { n: 2 }]
+        expect(sortObjectNumbers(arr, "n" as any).map((a) => a.n)).toEqual([1, 2, 3])
+    })
+    it("sorts descending when reverse=true", () => {
+        const arr = [{ n: 1 }, { n: 3 }, { n: 2 }]
+        expect(sortObjectNumbers(arr, "n" as any, true).map((a) => a.n)).toEqual([3, 2, 1])
+    })
+    it("returns [] for non-array input", () => {
+        expect(sortObjectNumbers(undefined as any, "n" as any)).toEqual([])
+    })
+})
+
+describe("sortByNameAndNumber (quick-access hymn numbers)", () => {
+    const item = (name: string, number?: string) => ({ name, quickAccess: number ? { number } : undefined })
+
+    it("sorts by numeric core when prefixes match", () => {
+        const arr = [item("c", "MP10"), item("a", "MP2"), item("b", "MP1")]
+        expect(sortByNameAndNumber(arr).map((a) => a.name)).toEqual(["b", "a", "c"])
+    })
+    it("sorts by prefix first, then number", () => {
+        const arr = [item("c", "MP1"), item("a", "AB99"), item("b", "MP2")]
+        expect(sortByNameAndNumber(arr).map((a) => a.name)).toEqual(["a", "c", "b"])
+    })
+    it("always pushes items without a number to the end", () => {
+        const arr = [item("hasnum", "MP1"), item("nonum")]
+        expect(sortByNameAndNumber(arr).map((a) => a.name)).toEqual(["hasnum", "nonum"])
+    })
+    it("supports descending direction", () => {
+        const arr = [item("a", "MP1"), item("b", "MP2"), item("c", "MP3")]
+        expect(sortByNameAndNumber(arr, "desc").map((a) => a.name)).toEqual(["c", "b", "a"])
+    })
+    it("returns [] for non-array input", () => {
+        expect(sortByNameAndNumber(null as any)).toEqual([])
+    })
+})
+
+describe("sortFilenames", () => {
+    it("sorts numerically within the same base name", () => {
+        const arr = [{ name: "img10.png" }, { name: "img2.png" }, { name: "img1.png" }]
+        expect(sortFilenames(arr).map((a) => a.name)).toEqual(["img1.png", "img2.png", "img10.png"])
+    })
+    it("falls back to extension comparison when name+number match", () => {
+        const arr = [{ name: "song1.wav" }, { name: "song1.mp3" }]
+        expect(sortFilenames(arr).map((a) => a.name)).toEqual(["song1.mp3", "song1.wav"])
+    })
+})
+
+describe("keysToID", () => {
+    it("moves the object key onto each entry as `id`", () => {
+        expect(keysToID({ a: { x: 1 }, b: { x: 2 } })).toEqual([
+            { id: "a", x: 1 },
+            { id: "b", x: 2 }
+        ])
+    })
+    it("returns [] for falsy input", () => {
+        expect(keysToID(null as any)).toEqual([])
+    })
+})
+
+describe("removeValues / removeDeleted / removeDuplicateValues", () => {
+    it("removeValues drops entries where key === value", () => {
+        expect(removeValues([{ n: 1 }, { n: 2 }, { n: 1 }] as any, "n" as any, 1)).toEqual([{ n: 2 }])
+    })
+    it("removeDeleted filters out entries with a truthy `deleted`", () => {
+        const arr = [{ id: "a" }, { id: "b", deleted: true }, { id: "c" }] as any
+        expect(removeDeleted(arr).map((a: any) => a.id)).toEqual(["a", "c"])
+    })
+    it("removeDuplicateValues keeps only the first occurrence per JSON-equal value", () => {
+        const result = removeDuplicateValues({ a: { x: 1 }, b: { x: 1 }, c: { x: 2 } })
+        expect(Object.keys(result)).toEqual(["a", "c"])
+    })
+})
+
+describe("changeValues", () => {
+    it("assigns provided values and deletes keys set to undefined", () => {
+        const target: any = { a: 1, b: 2 }
+        changeValues(target, { a: 10, b: undefined, c: 3 })
+        expect(target).toEqual({ a: 10, c: 3 })
+    })
+})
+
+describe("clone", () => {
+    it("returns a deep copy so mutations don't leak to the original", () => {
+        const source = { a: { b: 1 } }
+        const copy = clone(source)
+        copy.a.b = 99
+        expect(source.a.b).toBe(1)
+    })
+    it("returns primitives and null as-is", () => {
+        expect(clone(5 as any)).toBe(5)
+        expect(clone(null as any)).toBe(null)
+    })
+})
+
+describe("rangeSelect (list multi-select with modifier keys)", () => {
+    it("no modifier: replaces the selection with just the clicked item", () => {
+        expect(rangeSelect({}, [1, 2, 3], 5)).toEqual([5])
+    })
+    it("ctrl: toggles the clicked item in/out of the selection", () => {
+        expect(rangeSelect({ ctrlKey: true }, [1, 2], 3)).toEqual([1, 2, 3])
+        expect(rangeSelect({ ctrlKey: true }, [1, 2, 3], 2)).toEqual([1, 3])
+    })
+    it("meta (macOS): behaves like ctrl", () => {
+        expect(rangeSelect({ metaKey: true }, [1], 2)).toEqual([1, 2])
+    })
+    it("shift: fills the range between the last selected and the new index", () => {
+        // last selected 2, clicked 5 → fills 3,4 into the selection
+        const result = rangeSelect({ shiftKey: true }, [2], 5) as number[]
+        expect(result).toEqual(expect.arrayContaining([2, 3, 4, 5]))
+    })
+})
+
+describe("areObjectsEqual", () => {
+    it("returns true regardless of key insertion order", () => {
+        expect(areObjectsEqual({ a: 1, b: 2 }, { b: 2, a: 1 })).toBe(true)
+    })
+    it("returns false when a value differs", () => {
+        expect(areObjectsEqual({ a: 1 }, { a: 2 })).toBe(false)
+    })
+})
+
+describe("getChangedKeys", () => {
+    it("reports the keys that changed between the two aligned arrays", () => {
+        const prev = [{ a: 1, b: 2 }]
+        const curr = [{ a: 1, b: 3, c: 4 }]
+        const changed = getChangedKeys(curr, prev)
+        expect(changed).toEqual(
+            expect.arrayContaining([
+                { key: "b", index: 0 },
+                { key: "c", index: 0 }
+            ])
+        )
+        expect(changed.find((c) => c.key === "a")).toBeUndefined()
+    })
+})

--- a/src/frontend/components/helpers/bytes.test.ts
+++ b/src/frontend/components/helpers/bytes.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest"
+import { formatBytes } from "./bytes"
+
+describe("formatBytes", () => {
+    it("returns '0 Bytes' for zero", () => {
+        expect(formatBytes(0)).toBe("0 Bytes")
+    })
+    it("formats small values as Bytes", () => {
+        expect(formatBytes(500)).toBe("500 Bytes")
+    })
+    it("formats values in KB / MB / GB using powers of 1024", () => {
+        expect(formatBytes(1024)).toBe("1 KB")
+        expect(formatBytes(1024 * 1024)).toBe("1 MB")
+        expect(formatBytes(1024 * 1024 * 1024)).toBe("1 GB")
+    })
+    it("respects the decimals argument", () => {
+        // 1536 bytes = 1.5 KB
+        expect(formatBytes(1536, 1)).toBe("1.5 KB")
+        expect(formatBytes(1536, 0)).toBe("2 KB") // rounded from 1.5
+    })
+    it("treats a negative decimals argument as 0 (defensive)", () => {
+        expect(formatBytes(1536, -3)).toBe("2 KB")
+    })
+})

--- a/src/frontend/components/helpers/color.test.ts
+++ b/src/frontend/components/helpers/color.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest"
+import { defaultColors, fadeColor, getContrast, hexToHSL, hexToRgb, hslToHex, rgbToHex, splitGradientValue, splitRgb } from "./color"
+
+describe("hexToRgb", () => {
+    it("parses a 6-digit hex color", () => {
+        expect(hexToRgb("#FF8000")).toEqual({ r: 255, g: 128, b: 0 })
+    })
+    it("accepts hex without a leading #", () => {
+        expect(hexToRgb("00FF00")).toEqual({ r: 0, g: 255, b: 0 })
+    })
+    it("returns zeros for an invalid string (defensive)", () => {
+        expect(hexToRgb("not-a-color")).toEqual({ r: 0, g: 0, b: 0 })
+    })
+})
+
+describe("splitRgb", () => {
+    it("parses legacy rgba() syntax", () => {
+        expect(splitRgb("rgba(10, 20, 30, 0.5)")).toEqual({ r: 10, g: 20, b: 30, a: 0.5 })
+    })
+    it("parses modern space-separated rgb() with / alpha", () => {
+        expect(splitRgb("rgb(10 20 30 / 0.25)")).toEqual({ r: 10, g: 20, b: 30, a: 0.25 })
+    })
+    it("defaults alpha to 1 when missing", () => {
+        expect(splitRgb("rgb(1,2,3)")).toEqual({ r: 1, g: 2, b: 3, a: 1 })
+    })
+})
+
+describe("rgbToHex", () => {
+    it("round-trips through hexToRgb", () => {
+        expect(rgbToHex("rgb(255, 128, 0)").toLowerCase()).toBe("#ff8000")
+    })
+    it("pads single-digit hex components", () => {
+        expect(rgbToHex("rgb(1, 2, 3)").toLowerCase()).toBe("#010203")
+    })
+})
+
+describe("fadeColor", () => {
+    it("adds an alpha channel to a hex color", () => {
+        expect(fadeColor("#FF8000", 0.5)).toBe("rgba(255, 128, 0, 0.5)")
+    })
+    it("defaults alpha to 0.5 when omitted", () => {
+        expect(fadeColor("#000000")).toBe("rgba(0, 0, 0, 0.5)")
+    })
+})
+
+describe("getContrast (readable text on a background)", () => {
+    it("returns black on a light background", () => {
+        expect(getContrast("#FFFFFF")).toBe("#000000")
+    })
+    it("returns white on a dark background", () => {
+        expect(getContrast("#000000")).toBe("#FFFFFF")
+    })
+    it("returns white for a non-string input (defensive)", () => {
+        expect(getContrast(undefined as any)).toBe("#FFFFFF")
+    })
+})
+
+describe("hexToHSL / hslToHex round-trip", () => {
+    // hex→hsl→hex should recover the original color within rounding tolerance.
+    // We check a spread of hues (defaultColors is the app's own palette).
+    it.each(defaultColors.filter((c) => c.value !== "#000000" && c.value !== "#FFFFFF"))("round-trips $name ($value)", ({ value }) => {
+        const hsl = hexToHSL(value)
+        const back = hslToHex(hsl.h, hsl.s, hsl.l).toLowerCase()
+        const original = value.toLowerCase()
+
+        // allow ±2 per channel: hexToHSL rounds h/s/l to 1 decimal, then hslToHex rounds
+        // rgb to integers — that's two rounding steps, so up to ±2 per channel is possible.
+        const toRgb = (hex: string) => [parseInt(hex.slice(1, 3), 16), parseInt(hex.slice(3, 5), 16), parseInt(hex.slice(5, 7), 16)]
+        const [r1, g1, b1] = toRgb(back)
+        const [r2, g2, b2] = toRgb(original)
+        expect(Math.abs(r1 - r2)).toBeLessThanOrEqual(2)
+        expect(Math.abs(g1 - g2)).toBeLessThanOrEqual(2)
+        expect(Math.abs(b1 - b2)).toBeLessThanOrEqual(2)
+    })
+
+    it("black stays black", () => {
+        const hsl = hexToHSL("#000000")
+        expect(hslToHex(hsl.h, hsl.s, hsl.l).toLowerCase()).toBe("#000000")
+    })
+    it("white stays white", () => {
+        const hsl = hexToHSL("#FFFFFF")
+        expect(hslToHex(hsl.h, hsl.s, hsl.l).toLowerCase()).toBe("#ffffff")
+    })
+    it("supports 3-digit shorthand hex", () => {
+        // #F00 → red
+        const hsl = hexToHSL("#F00")
+        expect(hsl.h).toBe(0)
+        expect(hslToHex(hsl.h, hsl.s, hsl.l).toLowerCase()).toBe("#ff0000")
+    })
+})
+
+describe("splitGradientValue", () => {
+    it("parses a linear-gradient with explicit degrees and positions", () => {
+        const g = splitGradientValue("linear-gradient(120deg, #FF0000 0%, #00FF00 50%, #0000FF 100%)")
+        expect(g.type).toBe("linear-gradient")
+        expect(g.deg).toBe(120)
+        expect(g.colors).toEqual([
+            { color: "#FF0000", pos: 0 },
+            { color: "#00FF00", pos: 50 },
+            { color: "#0000FF", pos: 100 }
+        ])
+    })
+
+    it("defaults angle to 180 when omitted", () => {
+        const g = splitGradientValue("linear-gradient(#FF0000, #00FF00)")
+        expect(g.deg).toBe(180)
+    })
+
+    it("auto-distributes missing positions across the stops", () => {
+        const g = splitGradientValue("linear-gradient(90deg, red, green, blue)")
+        expect(g.colors.map((c) => c.pos)).toEqual([0, 50, 100])
+    })
+
+    it("parses a radial-gradient with a shape", () => {
+        const g = splitGradientValue("radial-gradient(circle, #FF0000 0%, #0000FF 100%)")
+        expect(g.type).toBe("radial-gradient")
+        expect(g.shape).toBe("circle")
+        expect(g.colors).toHaveLength(2)
+    })
+
+    it("normalizes rgb() color stops to rgba()", () => {
+        const g = splitGradientValue("linear-gradient(90deg, rgb(255, 0, 0) 0%, rgb(0, 0, 255) 100%)")
+        expect(g.colors[0].color).toBe("rgba(255,0,0, 1)")
+        expect(g.colors[1].color).toBe("rgba(0,0,255, 1)")
+    })
+
+    it("returns an empty result for a non-gradient string", () => {
+        expect(splitGradientValue("not a gradient").colors).toEqual([])
+    })
+})

--- a/src/frontend/components/helpers/style.test.ts
+++ b/src/frontend/components/helpers/style.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest"
+import { getFilters, getStyles, removeText } from "./style"
+
+describe("removeText", () => {
+    it("strips everything that isn't a digit, dot, or minus sign", () => {
+        expect(removeText("12px")).toBe("12")
+        expect(removeText("-1.5rem")).toBe("-1.5")
+        expect(removeText("100%")).toBe("100")
+    })
+    it("returns an empty string when the input has no digits", () => {
+        expect(removeText("auto")).toBe("")
+    })
+    it("gracefully handles undefined (defensive — .replace could throw)", () => {
+        expect(removeText(undefined as any)).toBeUndefined()
+    })
+})
+
+describe("getStyles", () => {
+    it("parses a semicolon-separated inline style into an object", () => {
+        expect(getStyles("color: red; font-size: 14px")).toEqual({
+            color: "red",
+            "font-size": "14px"
+        })
+    })
+
+    it("returns {} for null/undefined/empty input", () => {
+        expect(getStyles(null)).toEqual({})
+        expect(getStyles(undefined)).toEqual({})
+        expect(getStyles("")).toEqual({})
+    })
+
+    it("trims whitespace around keys and values", () => {
+        expect(getStyles("  color :   blue  ")).toEqual({ color: "blue" })
+    })
+
+    it("ignores empty segments between semicolons", () => {
+        expect(getStyles("color: red;;font-size: 12px;")).toEqual({ color: "red", "font-size": "12px" })
+    })
+
+    it("with removeTxt=true, strips units from a plain numeric style", () => {
+        // font-size is not on the "don't replace" list and doesn't include color/background, so it gets stripped
+        expect(getStyles("font-size: 14px", true)["font-size"]).toBe("14")
+    })
+
+    it("with removeTxt=true, preserves color/background values (they legitimately hold non-numeric text)", () => {
+        const styles = getStyles("color: #fff; background: red", true)
+        expect(styles.color).toBe("#fff")
+        expect(styles.background).toBe("red")
+    })
+
+    it("with removeTxt=true, preserves keys on the don't-replace list", () => {
+        // text-decoration / text-transform / text-shadow / box-shadow / font-family / transform are protected
+        expect(getStyles("text-decoration: underline", true)["text-decoration"]).toBe("underline")
+        expect(getStyles("font-family: Arial", true)["font-family"]).toBe("Arial")
+    })
+
+    it("hoists transform() functions into individual keys via getFilters", () => {
+        const styles = getStyles("transform: scale(1.5) rotate(45deg)")
+        // getFilters splits by space; the numeric value is extracted (removeText leaves digits/./-)
+        expect(styles.scale).toBe("1.5")
+        expect(styles.rotate).toBe("45")
+        // the original transform string is also retained
+        expect(styles.transform).toBe("scale(1.5) rotate(45deg)")
+    })
+})
+
+describe("getFilters", () => {
+    it("parses a space-separated filter list into name→value pairs", () => {
+        expect(getFilters("blur(4px) brightness(0.5)")).toEqual({ blur: "4", brightness: "0.5" })
+    })
+    it("returns {} for non-string input (defensive)", () => {
+        expect(getFilters(undefined)).toEqual({})
+        expect(getFilters(null as any)).toEqual({})
+        expect(getFilters(42 as any)).toEqual({})
+    })
+    it("handles a single filter with no space", () => {
+        expect(getFilters("blur(10px)")).toEqual({ blur: "10" })
+    })
+})

--- a/src/frontend/components/helpers/time.test.ts
+++ b/src/frontend/components/helpers/time.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi } from "vitest"
+
+// time.ts imports `dictionary` from ../../stores; that module drags a whole
+// dependency graph in. Stub the store so `get(dictionary)` returns an empty dict,
+// then pass explicit `d` args below where we care about translated output.
+vi.mock("../../stores", () => {
+    const makeStore = (initial: unknown) => ({ subscribe: (fn: (v: unknown) => void) => (fn(initial), () => {}) })
+    return { dictionary: makeStore({}) }
+})
+
+import { addZero, combineDateAndTime, dateToString, getMonthName, getTimeFromInterval, getWeekday, joinTime, joinTimeBig, padString, secondsToTime, splitDate, timeAgo } from "./time"
+
+describe("padString / addZero", () => {
+    it("pads a single-digit number to two chars", () => {
+        expect(padString(3)).toBe("03")
+        expect(addZero(3)).toBe("03")
+    })
+    it("leaves two-digit numbers alone", () => {
+        expect(padString(42)).toBe("42")
+    })
+})
+
+describe("secondsToTime", () => {
+    it("splits an hour + a bit into h/m/s components", () => {
+        // 3661 seconds = 1h 1m 1s
+        expect(secondsToTime(3661)).toMatchObject({ h: "01", m: "01", s: "01", d: 0 })
+    })
+    it("splits days off past 24 hours", () => {
+        // one full day plus 2 hours
+        expect(secondsToTime(86400 + 7200)).toMatchObject({ d: 1, h: "02", m: "00", s: "00" })
+    })
+    it("takes the absolute value (negative timer countdowns)", () => {
+        expect(secondsToTime(-90)).toMatchObject({ m: "01", s: "30" })
+    })
+})
+
+describe("joinTime / joinTimeBig", () => {
+    it("omits the hours component when it's zero", () => {
+        // secondsToTime(90) → 00:01:30 → joinTime drops leading 00 hours
+        expect(joinTime(secondsToTime(90))).toBe("01:30")
+    })
+    it("includes hours when present", () => {
+        // 3661 = 1h 1m 1s
+        expect(joinTime(secondsToTime(3661))).toBe("01:01:01")
+    })
+    it("joinTimeBig rolls hours into minutes when showHours=false", () => {
+        // 3720s = 1h 2m → shown as 62:00 when hours are collapsed
+        expect(joinTimeBig(3720, false)).toBe("62:00")
+    })
+    it("joinTimeBig keeps hours when showHours=true", () => {
+        expect(joinTimeBig(3720, true)).toBe("01:02:00")
+    })
+})
+
+describe("dateToString", () => {
+    it("formats a date as DD.MM.YY by default", () => {
+        // Jan 5 2023 → "05.01.23"
+        expect(dateToString(new Date(2023, 0, 5))).toBe("05.01.23")
+    })
+    it("returns an empty string for a falsy input", () => {
+        expect(dateToString(0 as any)).toBe("")
+        expect(dateToString("" as any)).toBe("")
+    })
+})
+
+describe("getWeekday / getMonthName", () => {
+    it("returns the English weekday when the dictionary is empty", () => {
+        expect(getWeekday(1, {} as any)).toBe("Monday")
+        expect(getWeekday(0, {} as any)).toBe("Sunday")
+    })
+    it("uppercases the first letter when asked", () => {
+        // "monday" from dict → "Monday"; already-uppercased stays the same
+        expect(getWeekday(1, { weekday: { 1: "monday" } } as any, true)).toBe("Monday")
+    })
+    it("returns the English month name when the dictionary is empty", () => {
+        expect(getMonthName(0, {} as any)).toBe("January")
+        expect(getMonthName(11, {} as any)).toBe("December")
+    })
+})
+
+describe("splitDate / combineDateAndTime", () => {
+    it("splitDate returns the individual fields", () => {
+        const d = new Date(2023, 5, 15, 14, 30)
+        expect(splitDate(d)).toEqual({ date: 15, month: 5, year: 2023, hours: 14, minutes: 30 })
+    })
+    it("combineDateAndTime stitches an HH:MM string onto a date", () => {
+        const base = new Date(2023, 5, 15, 8, 0)
+        const combined = combineDateAndTime(base, "14:45")
+        expect(combined.getHours()).toBe(14)
+        expect(combined.getMinutes()).toBe(45)
+        expect(combined.getDate()).toBe(15)
+    })
+    it("combineDateAndTime returns the date unchanged when time isn't a string", () => {
+        const base = new Date(2023, 5, 15, 8, 0)
+        expect(combineDateAndTime(base, undefined as any).getTime()).toBe(base.getTime())
+    })
+})
+
+describe("timeAgo", () => {
+    it("returns 'just now' for a very recent timestamp", () => {
+        expect(timeAgo(Date.now() - 100)).toBe("just now")
+    })
+    it("formats seconds correctly (singular/plural)", () => {
+        // note: the "second" interval kicks in strictly ABOVE 1s ago; exactly 1s ago is "just now"
+        expect(timeAgo(Date.now() - 2_000)).toBe("2 seconds ago")
+        expect(timeAgo(Date.now() - 5_000)).toBe("5 seconds ago")
+    })
+    it("formats minutes correctly", () => {
+        expect(timeAgo(Date.now() - 3 * 60 * 1000)).toBe("3 minutes ago")
+    })
+    it("returns empty string for falsy time (no timestamp)", () => {
+        expect(timeAgo(0)).toBe("")
+    })
+})
+
+describe("getTimeFromInterval", () => {
+    it("returns the millisecond count for each named interval", () => {
+        expect(getTimeFromInterval("daily")).toBe(86_400_000)
+        expect(getTimeFromInterval("weekly")).toBe(604_800_000)
+    })
+    it("returns 0 for an unknown interval", () => {
+        expect(getTimeFromInterval("hourly" as any)).toBe(0)
+    })
+})

--- a/src/frontend/converters/propresenter.ts
+++ b/src/frontend/converters/propresenter.ts
@@ -304,35 +304,40 @@ function getSlideItems(slide: any) {
 
     const items: Item[] = []
 
-    const textElement = elements.RVTextElement
-    let itemStrings = elements.RVTextElement.NSString
-    if (!itemStrings && Array.isArray(textElement)) itemStrings = textElement.map((a) => a.NSString)
-    if (!itemStrings) itemStrings = [elements.RVTextElement["@RTFData"]]
-    else if (itemStrings["#text"]) itemStrings = [itemStrings]
+    // Handle multiple RVTextElement items (common in Pro6)
+    const textElements = Array.isArray(elements.RVTextElement) ? elements.RVTextElement : [elements.RVTextElement]
 
-    itemStrings = itemStrings.filter(Boolean)
+    textElements.forEach((textElement: any) => {
+        if (!textElement) return
 
-    const rtf = itemStrings.find((a) => a["@rvXMLIvarName"] === "RTFData")
-    const plain = itemStrings.find((a) => a["@rvXMLIvarName"] === "PlainText")
-    // rtf includes line breaks
-    if (rtf) itemStrings = [rtf]
-    else if (plain) itemStrings = [plain]
+        let itemStrings = textElement.NSString
+        if (!itemStrings) itemStrings = [textElement["@RTFData"]]
+        else if (itemStrings["#text"]) itemStrings = [itemStrings]
 
-    itemStrings.forEach((content: any) => {
-        if (!content) return
-        if (Array.isArray(content)) content = content[0]
+        itemStrings = itemStrings.filter(Boolean)
 
-        let text = decodeBase64(content["#text"] || content)
-        // console.log(text)
+        const rtf = itemStrings.find((a) => a["@rvXMLIvarName"] === "RTFData")
+        const plain = itemStrings.find((a) => a["@rvXMLIvarName"] === "PlainText")
+        // rtf includes line breaks
+        if (rtf) itemStrings = [rtf]
+        else if (plain) itemStrings = [plain]
 
-        const type = content["@rvXMLIvarName"]
-        if (type && type !== "RTFData" && type !== "PlainText") return
-        // text = convertFromRTFToPlain(text)
-        text = decodeHex(text)
-        // console.log(text)
+        itemStrings.forEach((content: any) => {
+            if (!content) return
+            if (Array.isArray(content)) content = content[0]
 
-        if (text === "Double-click to edit") text = ""
-        items.push({ style: DEFAULT_ITEM_STYLE, lines: splitTextToLines(text) })
+            let text = decodeBase64(content["#text"] || content)
+            // console.log(text)
+
+            const type = content["@rvXMLIvarName"]
+            if (type && type !== "RTFData" && type !== "PlainText") return
+            // text = convertFromRTFToPlain(text)
+            text = decodeHex(text)
+            // console.log(text)
+
+            if (text === "Double-click to edit") text = ""
+            items.push({ style: DEFAULT_ITEM_STYLE, lines: splitTextToLines(text) })
+        })
     })
 
     return items

--- a/src/frontend/converters/propresenter.ts
+++ b/src/frontend/converters/propresenter.ts
@@ -1,4 +1,3 @@
-import { _updaters } from "./../components/helpers/historyHelpers"
 import { get } from "svelte/store"
 import { uid } from "uid"
 import type { Item, Layout, Line, Slide, SlideData, Timeline } from "../../types/Show"
@@ -11,141 +10,165 @@ import { activePopup, alertMessage, groups, shows } from "./../stores"
 import { createCategory, setTempShows } from "./importHelpers"
 import { xml2json } from "./xml"
 
-export function convertProPresenter(data: any) {
+type ImportFile = { content: any; name: string; extension: string }
+type ConvertedShow = { slides: Record<string, Slide>; layouts: any[]; media?: Record<string, any> }
+
+const DEFAULT_GROUP = "verse"
+const PLACEHOLDER_TEXT = "Double-click to edit"
+
+export function convertProPresenter(data: ImportFile[]) {
     alertMessage.set("popup.importing")
     activePopup.set("alert")
 
     const categoryId = createCategory("ProPresenter")
-
-    // JSON Bundle
-    const newData: any[] = []
-    data?.forEach(({ content, name, extension }: any) => {
-        if (extension !== "json") return
-
-        let song: any = {}
-        try {
-            song = JSON.parse(content)
-        } catch (err) {
-            console.error(err)
-        }
-
-        if (Array.isArray(song.data)) {
-            song.data.forEach((songData) => {
-                newData.push({ content: songData, name, extension: "jsonbundle" })
-            })
-        }
-    })
-    if (newData.length) data = newData
-
+    const files = expandJsonBundles(data)
     const tempShows: any[] = []
 
     setTimeout(() => {
-        data?.forEach(({ content, name, extension }: any) => {
-            let song: any = {}
-
-            if (!content) {
-                console.error("File missing content!")
-                return
-            }
-
-            if (extension === "json" || extension === "pro") {
-                try {
-                    song = JSON.parse(content)
-                } catch (err) {
-                    console.error(err)
-                }
-            } else if (extension === "jsonbundle") {
-                song = content
-            } else {
-                song = xml2json(content)?.RVPresentationDocument
-            }
-
-            if (!song) return
-
-            const layoutID = uid()
-            const show = new ShowObj(false, categoryId, layoutID)
-            let showId = song["@uuid"] || song.uuid?.string || song._id || uid()
-            show.origin = "propresenter"
-            show.name = checkName(song.name === "Untitled" ? name : song.name || song.title || name, showId)
-
-            // propresenter often uses the same id for duplicated songs
-            const existingShow = get(shows)[showId] || tempShows.find((a) => a.id === showId)?.show
-            if (existingShow && existingShow.name !== (song.name || name)) showId = uid()
-
-            let converted: any = {}
-
-            if (extension === "pro") {
-                converted = convertProToSlides(song)
-            } else if (extension === "json") {
-                converted = convertJSONToSlides(song)
-            } else if (extension === "jsonbundle") {
-                converted = convertJSONBundleToSlides(song)
-            } else {
-                converted = convertToSlides(song, extension)
-            }
-
-            const { slides, layouts, media }: any = converted
-            if (!Object.keys(slides).length) return
-
-            show.slides = slides
-            show.layouts = {}
-            show.media = media
-
-            show.meta = initializeMetadata({
-                title: song["@CCLISongTitle"] || song.ccli?.songTitle,
-                artist: song["@CCLIArtistCredits"],
-                author: song["@CCLIAuthor"] || song.ccli?.author || song.author,
-                publisher: song["@CCLIPublisher"] || song.ccli?.publisher,
-                copyright: song.copyrights_info,
-                CCLI: song["@CCLISongNumber"] || song.ccli?.songNumber,
-                year: song["@CCLICopyrightYear"] || song.ccli?.copyrightYear
-            })
-
-            layouts.forEach((layout: any, i: number) => {
-                let layoutId = i === 0 ? layoutID : layout.id
-                show.layouts[layoutId] = {
-                    name: layout.name || translateText("example.default"),
-                    notes: i === 0 ? song["@notes"] || "" : "",
-                    slides: layout.slides
-                }
-                if (layout.timeline) show.layouts[layoutId].timeline = layout.timeline
-            })
-
-            tempShows.push({ id: showId, show })
+        files?.forEach((file) => {
+            const show = importFile(file, categoryId, tempShows)
+            if (show) tempShows.push(show)
         })
 
         setTempShows(tempShows)
     }, 50)
 }
 
-function convertJSONBundleToSlides(song: any) {
-    const slides: any = {}
-    const layoutSlides: any = []
+// A single .json input may hold multiple songs bundled together — expand each one
+// into its own file entry so downstream code handles them uniformly.
+function expandJsonBundles(data: ImportFile[]): ImportFile[] {
+    const expanded: ImportFile[] = []
+    data?.forEach(({ content, name, extension }) => {
+        if (extension !== "json") return
 
+        const song = safeParseJson(content)
+        if (!Array.isArray(song?.data)) return
+
+        song.data.forEach((songData: any) => {
+            expanded.push({ content: songData, name, extension: "jsonbundle" })
+        })
+    })
+    return expanded.length ? expanded : data
+}
+
+function importFile({ content, name, extension }: ImportFile, categoryId: string, tempShows: any[]) {
+    if (!content) {
+        console.error("File missing content!")
+        return null
+    }
+
+    const song = parseSong(content, extension)
+    if (!song) return null
+
+    const layoutId = uid()
+    const show = new ShowObj(false, categoryId, layoutId)
+    show.origin = "propresenter"
+
+    const showId = resolveShowId(song, name, tempShows)
+    show.name = checkName(resolveShowName(song, name), showId)
+
+    const converted = runConverter(song, extension)
+    if (!Object.keys(converted.slides).length) return null
+
+    show.slides = converted.slides
+    show.layouts = {}
+    show.media = converted.media || {}
+    show.meta = buildMetadata(song)
+
+    applyLayouts(show, converted.layouts, layoutId, song["@notes"] || "")
+
+    return { id: showId, show }
+}
+
+function parseSong(content: any, extension: string): any | null {
+    if (extension === "json" || extension === "pro") return safeParseJson(content)
+    if (extension === "jsonbundle") return content
+    return xml2json(content)?.RVPresentationDocument
+}
+
+function safeParseJson(content: string): any {
+    try {
+        return JSON.parse(content)
+    } catch (err) {
+        console.error(err)
+        return {}
+    }
+}
+
+function resolveShowName(song: any, fallback: string): string {
+    if (song.name === "Untitled") return fallback
+    return song.name || song.title || fallback
+}
+
+// ProPresenter often reuses the same id for duplicated songs — generate a fresh id
+// when we detect a name collision so the existing show is not overwritten.
+function resolveShowId(song: any, name: string, tempShows: any[]): string {
+    const originalId = song["@uuid"] || song.uuid?.string || song._id || uid()
+    const existingShow = get(shows)[originalId] || tempShows.find((a) => a.id === originalId)?.show
+    if (existingShow && existingShow.name !== (song.name || name)) return uid()
+    return originalId
+}
+
+function runConverter(song: any, extension: string): ConvertedShow {
+    if (extension === "pro") return convertProToSlides(song)
+    if (extension === "json") return convertJSONToSlides(song)
+    if (extension === "jsonbundle") return convertJSONBundleToSlides(song)
+    return convertToSlides(song, extension)
+}
+
+function buildMetadata(song: any) {
+    return initializeMetadata({
+        title: song["@CCLISongTitle"] || song.ccli?.songTitle,
+        artist: song["@CCLIArtistCredits"],
+        author: song["@CCLIAuthor"] || song.ccli?.author || song.author,
+        publisher: song["@CCLIPublisher"] || song.ccli?.publisher,
+        copyright: song.copyrights_info,
+        CCLI: song["@CCLISongNumber"] || song.ccli?.songNumber,
+        year: song["@CCLICopyrightYear"] || song.ccli?.copyrightYear
+    })
+}
+
+function applyLayouts(show: any, layouts: any[], defaultLayoutId: string, notes: string) {
+    layouts.forEach((layout, i) => {
+        const layoutId = i === 0 ? defaultLayoutId : layout.id
+        show.layouts[layoutId] = {
+            name: layout.name || translateText("example.default"),
+            notes: i === 0 ? notes : "",
+            slides: layout.slides
+        }
+        if (layout.timeline) show.layouts[layoutId].timeline = layout.timeline
+    })
+}
+
+// ----- JSON bundle -----
+
+function convertJSONBundleToSlides(song: any): ConvertedShow {
+    const slides: Record<string, Slide> = {}
+    const layoutSlides: any[] = []
     const parentId = uid()
     const children: string[] = []
 
-    song.lyrics.forEach(({ lyrics }) => {
+    song.lyrics.forEach(({ lyrics }: any) => {
         if (!lyrics) return
 
-        const parent = !Object.keys(slides).length
-        const id: string = parent ? parentId : uid()
+        const isParent = !Object.keys(slides).length
+        const id = isParent ? parentId : uid()
 
-        if (parent) layoutSlides.push({ id })
+        if (isParent) layoutSlides.push({ id })
 
-        lyrics = lyrics.replaceAll("<p>", "").replaceAll("</p>", "")
-        const items = [
+        const cleaned = lyrics.replaceAll("<p>", "").replaceAll("</p>", "")
+        const items: Item[] = [
             {
                 style: DEFAULT_ITEM_STYLE,
-                lines: lyrics.split("<br>").map((a: any) => ({ align: "", text: [{ style: "", value: a }] }))
+                lines: cleaned.split("<br>").map((line: string) => ({ align: "", text: [{ style: "", value: line }] }))
             }
         ]
 
         slides[id] = newSlide({ items })
 
-        if (parent) {
+        if (isParent) {
             slides[id].group = ""
-            if (get(groups).verse) slides[id].globalGroup = "verse"
+            if (get(groups).verse) slides[id].globalGroup = DEFAULT_GROUP
         } else {
             children.push(id)
         }
@@ -157,37 +180,39 @@ function convertJSONBundleToSlides(song: any) {
     return { slides, layouts }
 }
 
-const JSONgroups: any = { V: "verse", C: "chorus", B: "bridge", T: "tag", O: "outro" }
-function convertJSONToSlides(song: any) {
-    const slides: any = {}
-    let layoutSlides: any = []
+// ----- JSON (OpenLP/other) -----
 
-    const initialSlidesList: string[] = song.verse_order_list || []
+const JSON_GROUPS: Record<string, string> = { V: "verse", C: "chorus", B: "bridge", T: "tag", O: "outro" }
+
+function convertJSONToSlides(song: any): ConvertedShow {
+    const slides: Record<string, Slide> = {}
+    let layoutSlides: any[] = []
+    const slidesRef: Record<string, string> = {}
     let slidesList: string[] = []
-    const slidesRef: any = {}
 
-    song.verses?.forEach(([text, label]) => {
+    song.verses?.forEach(([text, label]: [string, string]) => {
         if (!text) return
 
-        const id: string = uid()
+        const id = uid()
         slidesList.push(label)
         slidesRef[label] = id
 
         layoutSlides.push({ id })
 
-        const items = [
+        const items: Item[] = [
             {
                 style: DEFAULT_ITEM_STYLE,
-                lines: text.split("\n").map((a: any) => ({ align: "", text: [{ style: "", value: a }] }))
+                lines: text.split("\n").map((line: string) => ({ align: "", text: [{ style: "", value: line }] }))
             }
         ]
 
         slides[id] = newSlide({ items })
 
-        const globalGroup = label ? JSONgroups[label.replace(/[0-9]/g, "").toUpperCase()] : "verse"
+        const globalGroup = label ? JSON_GROUPS[label.replace(/[0-9]/g, "").toUpperCase()] : DEFAULT_GROUP
         if (get(groups)[globalGroup]) slides[id].globalGroup = globalGroup
     })
 
+    const initialSlidesList: string[] = song.verse_order_list || []
     if (initialSlidesList.length) slidesList = initialSlidesList
     if (slidesList.length) {
         layoutSlides = []
@@ -200,85 +225,102 @@ function convertJSONToSlides(song: any) {
     return { slides, layouts }
 }
 
-function convertToSlides(song: any, extension: string) {
-    let slideGroups: any = []
-    if (extension === "pro4") slideGroups = song.slides?.RVDisplaySlide || []
-    if (extension === "pro5") slideGroups = song.groups?.RVSlideGrouping || []
-    if (extension === "pro6") slideGroups = song.array?.[0]?.RVSlideGrouping || []
-    if (!Array.isArray(slideGroups)) slideGroups = slideGroups ? [slideGroups] : []
+// ----- Pro4 / Pro5 / Pro6 (XML) -----
+
+function convertToSlides(song: any, extension: string): ConvertedShow {
+    const slideGroups = getSlideGroups(song, extension)
     const arrangements = song.arrangements || song.array?.[1]?.RVSongArrangement || []
 
-    // console.log(song)
-
-    const slides: any = {}
+    const slides: Record<string, Slide> = {}
     const layouts: any[] = [{ id: null, name: "", slides: [] }]
-    const media: any = {}
-    const sequences: any = {}
+    const media: Record<string, any> = {}
+    const sequences: Record<string, string> = {}
+    const backgrounds: any[] = []
 
-    const backgrounds: any = []
-
-    slideGroups.forEach((group) => {
-        let groupSlides = group
-        if (extension === "pro4") groupSlides = [groupSlides]
-        if (extension === "pro5") groupSlides = groupSlides.slides.RVDisplaySlide
-        if (extension === "pro6" && groupSlides.array) groupSlides = groupSlides.array.RVDisplaySlide
-        if (!Array.isArray(groupSlides)) groupSlides = [groupSlides]
-        if (!groupSlides?.length) return
+    slideGroups.forEach((group: any) => {
+        const groupSlides = getGroupSlides(group, extension)
+        if (!groupSlides.length) return
 
         let slideIndex = -1
-        groupSlides.forEach((slide) => {
+        groupSlides.forEach((slide: any) => {
             const items = getSlideItems(slide)
-            // console.log(slide, items)
-            if (!items?.length) return
+            if (!items.length) return
             slideIndex++
 
-            const slideIsDisabled = slide["@enabled"] === "false"
-            const slideId: string = uid()
-
+            const slideId = uid()
+            const isDisabled = slide["@enabled"] === "false"
             slides[slideId] = newSlide({ notes: slide["@notes"] || "", items })
 
-            // media
-            const mediaCue = slide.RVMediaCue
+            const background = extractSlideBackground(slide)
+            if (background) backgrounds[slideIndex] = background
 
-            // TODO: images
-            const path: string = mediaCue?.RVVideoElement?.["@source"] || ""
-            if (path) backgrounds[slideIndex] = { path, name: mediaCue["@displayName"] || "" }
-
-            const isFirstSlide: boolean = slideIndex === 0
-            if (isFirstSlide) {
-                slides[slideId] = makeParentSlide(slides[slideId], {
-                    label: group["@name"] || slides[slideId]["@label"] || "",
-                    color: group["@color"] || slides[slideId]["@highlightColor"]
+            if (slideIndex === 0) {
+                const parent: any = slides[slideId]
+                slides[slideId] = makeParentSlide(parent, {
+                    label: group["@name"] || parent["@label"] || "",
+                    color: group["@color"] || parent["@highlightColor"]
                 })
 
-                const groupId = group["@uuid"]
-                sequences[groupId] = slideId
+                sequences[group["@uuid"]] = slideId
 
-                const l: any = { id: slideId }
-                if (slideIsDisabled) l.disabled = true
-                layouts[0].slides.push(l)
+                const layoutSlide: any = { id: slideId }
+                if (isDisabled) layoutSlide.disabled = true
+                layouts[0].slides.push(layoutSlide)
             } else {
-                // children
-                const parentLayout = layouts[0].slides[layouts[0].slides.length - 1]
-                const parentSlide = slides[parentLayout.id]
-                if (!parentSlide.children) parentSlide.children = []
-                parentSlide.children.push(slideId)
-
-                if (slideIsDisabled) {
-                    if (!parentLayout.children) parentLayout.children = {}
-                    parentLayout.children[slideId] = { disabled: true }
-                }
+                addChildSlide(slides, layouts[0], slideId, isDisabled)
             }
         })
     })
 
     if (arrangements.length) {
-        const newLayouts = arrangeLayouts(arrangements, sequences)
-        // if (newLayouts.length) layouts = newLayouts
-        if (newLayouts.length) layouts.push(...newLayouts)
+        const arranged = arrangeLayouts(arrangements, sequences)
+        if (arranged.length) layouts.push(...arranged)
     }
 
-    backgrounds.forEach((background: any, i: number) => {
+    attachBackgrounds(layouts, backgrounds, media)
+
+    return { slides, layouts, media }
+}
+
+function getSlideGroups(song: any, extension: string): any[] {
+    let slideGroups: any = []
+    if (extension === "pro4") slideGroups = song.slides?.RVDisplaySlide || []
+    if (extension === "pro5") slideGroups = song.groups?.RVSlideGrouping || []
+    if (extension === "pro6") slideGroups = song.array?.[0]?.RVSlideGrouping || []
+    if (!Array.isArray(slideGroups)) slideGroups = slideGroups ? [slideGroups] : []
+    return slideGroups
+}
+
+function getGroupSlides(group: any, extension: string): any[] {
+    let groupSlides = group
+    if (extension === "pro4") groupSlides = [groupSlides]
+    if (extension === "pro5") groupSlides = groupSlides.slides.RVDisplaySlide
+    if (extension === "pro6" && groupSlides.array) groupSlides = groupSlides.array.RVDisplaySlide
+    if (!Array.isArray(groupSlides)) groupSlides = groupSlides ? [groupSlides] : []
+    return groupSlides
+}
+
+function extractSlideBackground(slide: any) {
+    const mediaCue = slide.RVMediaCue
+    const path: string = mediaCue?.RVVideoElement?.["@source"] || ""
+    if (!path) return null
+    return { path, name: mediaCue["@displayName"] || "" }
+}
+
+function addChildSlide(slides: Record<string, Slide>, layout: any, childId: string, isDisabled: boolean) {
+    const parentLayout = layout.slides[layout.slides.length - 1]
+    const parentSlide = slides[parentLayout.id]
+    if (!parentSlide.children) parentSlide.children = []
+    parentSlide.children.push(childId)
+
+    if (isDisabled) {
+        if (!parentLayout.children) parentLayout.children = {}
+        parentLayout.children[childId] = { disabled: true }
+    }
+}
+
+function attachBackgrounds(layouts: any[], backgrounds: any[], media: Record<string, any>) {
+    backgrounds.forEach((background, i) => {
         if (!background || !layouts[i]) return
         if (!layouts[0].slides[i]) return
 
@@ -286,56 +328,21 @@ function convertToSlides(song: any, extension: string) {
         layouts[0].slides[i].background = id
         media[id] = background
     })
-
-    return { slides, layouts, media }
 }
 
-function getSlideItems(slide: any) {
+function getSlideItems(slide: any): Item[] {
     if (!slide) return []
 
-    let elements: any = null
-    if (slide.displayElements) elements = slide.displayElements
-    else elements = Array.isArray(slide.array) ? slide.array.find((a: any) => a["@rvXMLIvarName"] === "displayElements") : null
-    if (!elements) return []
-
-    if (!elements.RVTextElement) {
-        return []
-    }
+    const elements = getDisplayElements(slide)
+    if (!elements?.RVTextElement) return []
 
     const items: Item[] = []
-
-    // Handle multiple RVTextElement items (common in Pro6)
     const textElements = Array.isArray(elements.RVTextElement) ? elements.RVTextElement : [elements.RVTextElement]
 
     textElements.forEach((textElement: any) => {
         if (!textElement) return
 
-        let itemStrings = textElement.NSString
-        if (!itemStrings) itemStrings = [textElement["@RTFData"]]
-        else if (itemStrings["#text"]) itemStrings = [itemStrings]
-
-        itemStrings = itemStrings.filter(Boolean)
-
-        const rtf = itemStrings.find((a) => a["@rvXMLIvarName"] === "RTFData")
-        const plain = itemStrings.find((a) => a["@rvXMLIvarName"] === "PlainText")
-        // rtf includes line breaks
-        if (rtf) itemStrings = [rtf]
-        else if (plain) itemStrings = [plain]
-
-        itemStrings.forEach((content: any) => {
-            if (!content) return
-            if (Array.isArray(content)) content = content[0]
-
-            let text = decodeBase64(content["#text"] || content)
-            // console.log(text)
-
-            const type = content["@rvXMLIvarName"]
-            if (type && type !== "RTFData" && type !== "PlainText") return
-            // text = convertFromRTFToPlain(text)
-            text = decodeHex(text)
-            // console.log(text)
-
-            if (text === "Double-click to edit") text = ""
+        collectItemTexts(textElement).forEach((text) => {
             items.push({ style: DEFAULT_ITEM_STYLE, lines: splitTextToLines(text) })
         })
     })
@@ -343,113 +350,147 @@ function getSlideItems(slide: any) {
     return items
 }
 
-function makeParentSlide(slide, { label, color = "" }) {
+function getDisplayElements(slide: any) {
+    if (slide.displayElements) return slide.displayElements
+    if (Array.isArray(slide.array)) return slide.array.find((a: any) => a["@rvXMLIvarName"] === "displayElements")
+    return null
+}
+
+function collectItemTexts(textElement: any): string[] {
+    let itemStrings = textElement.NSString
+    if (!itemStrings) itemStrings = [textElement["@RTFData"]]
+    else if (itemStrings["#text"]) itemStrings = [itemStrings]
+
+    itemStrings = itemStrings.filter(Boolean)
+
+    // Prefer RTF (which preserves line breaks); fall back to PlainText.
+    const rtf = itemStrings.find((a: any) => a["@rvXMLIvarName"] === "RTFData")
+    const plain = itemStrings.find((a: any) => a["@rvXMLIvarName"] === "PlainText")
+    if (rtf) itemStrings = [rtf]
+    else if (plain) itemStrings = [plain]
+
+    const texts: string[] = []
+    itemStrings.forEach((content: any) => {
+        if (!content) return
+        if (Array.isArray(content)) content = content[0]
+
+        const type = content["@rvXMLIvarName"]
+        if (type && type !== "RTFData" && type !== "PlainText") return
+
+        let text = decodeBase64(content["#text"] || content)
+        text = decodeHex(text)
+        if (text === PLACEHOLDER_TEXT) text = ""
+        texts.push(text)
+    })
+
+    return texts
+}
+
+function makeParentSlide(slide: Slide, { label, color = "" }: { label: string; color?: string }): Slide {
     slide.group = label
     if (color) slide.color = rgbStringToHex(color)
+    // Black on black is invisible in the group label — fall back to white.
     if (color === "#000000") slide.color = "#ffffff"
 
-    // set global group
-    if (label.toLowerCase() === "group") label = "verse"
-    const globalGroup = getGlobalGroup(label)
-    // if (globalGroup && !label)
-    slide.globalGroup = globalGroup || "verse"
+    if (label.toLowerCase() === "group") label = DEFAULT_GROUP
+    slide.globalGroup = getGlobalGroup(label) || DEFAULT_GROUP
 
     return slide
 }
 
-function arrangeLayouts(arrangements, sequences) {
+function arrangeLayouts(arrangements: any[], sequences: Record<string, string>): Layout[] {
     const layouts: Layout[] = []
     arrangements.forEach((arrangement) => {
         let groupIds = arrangement.array?.NSString || []
         if (!Array.isArray(groupIds)) groupIds = [groupIds]
         if (!groupIds.length) return
 
-        const slides: any[] = groupIds.map((groupID) => ({ id: sequences[groupID] }))
+        const slides = groupIds.map((groupID: string) => ({ id: sequences[groupID] }))
         layouts.push({ id: arrangement["@uuid"], name: arrangement["@name"], notes: "", slides })
     })
 
     return layouts
 }
 
-/// //
+// ----- Text / RTF decoding -----
 
-function splitTextToLines(text: string) {
+function splitTextToLines(text: string): Line[] {
     if (typeof text !== "string") return []
-    let lines: Line[] = []
-    const data = text.replaceAll("\n\n", "<br>").split("<br>")
-    lines = data.map((lineText: string) => ({ align: "", text: [{ style: "", value: lineText.trim() }] }))
-
-    return lines
+    return text.replaceAll("\n\n", "<br>").split("<br>").map((lineText) => ({
+        align: "",
+        text: [{ style: "", value: lineText.trim() }]
+    }))
 }
 
-// replace all RTF hex codes (e.g., \'e5) with their latin1 character (e.g., å)
+// Replace all RTF hex codes (e.g., \'e5) with their latin1 character (e.g., å).
 function decodeLatin1HexRTF(input: string): string {
     return input.replace(/\\'([0-9a-fA-F]{2})/g, (_, hex) => {
         const byte = parseInt(hex, 16)
-
         if (typeof TextDecoder !== "undefined") {
             return new TextDecoder("latin1").decode(Uint8Array.from([byte]))
         }
-
-        // fallback
         return String.fromCharCode(byte)
     })
 }
 
-function decodeBase64(text: string) {
+function decodeBase64(text: string): string {
     if (typeof text !== "string") return ""
 
-    let b = 0
-    let l = 0
-    let r = ""
-    const m = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
-
-    text.split("").forEach(function (v) {
-        b = (b << 6) + m.indexOf(v)
-        l += 6
-        if (l >= 8) r += String.fromCharCode((b >>> (l -= 8)) & 0xff)
-    })
-
-    // WIP better RTF decoding
-    // https://github.com/ChurchApps/FreeShow/issues/1200
+    let r = decodeBase64Chars(text)
 
     // https://www.oreilly.com/library/view/rtf-pocket-guide/9781449302047/ch04.html
+    // https://github.com/ChurchApps/FreeShow/issues/1200
     r = r.replaceAll("\\u8217 ?", "'")
 
-    // convert ‘ & ’ to '
+    // Normalize curly quotes to a straight apostrophe.
     r = r.replaceAll("‘", "'").replaceAll("’", "'")
 
-    // decode Latin-1 hex codes
     r = decodeLatin1HexRTF(r)
-
-    // decode encoded unicode dec letters
-    // https://unicodelookup.com/
-    let decCode = r.indexOf("\\u")
-    while (decCode > -1) {
-        const endOfCode = r.indexOf(" ?", decCode) + 2
-
-        if (endOfCode > 1 && endOfCode - decCode <= 10) {
-            const decodedLetter = String.fromCharCode(Number(r.slice(decCode, endOfCode).replace(/[^\d-]/g, "")))
-            if (!decodedLetter.includes("\\x")) r = r.slice(0, decCode) + decodedLetter + r.slice(endOfCode)
-        }
-
-        decCode = r.indexOf("\\u", decCode + 1)
-    }
-
+    r = decodeUnicodeEscapes(r)
     return r
 }
 
-function RTFToText(input: string) {
+function decodeBase64Chars(text: string): string {
+    const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"
+    let bits = 0
+    let bitLength = 0
+    let result = ""
+
+    text.split("").forEach((char) => {
+        bits = (bits << 6) + alphabet.indexOf(char)
+        bitLength += 6
+        if (bitLength >= 8) result += String.fromCharCode((bits >>> (bitLength -= 8)) & 0xff)
+    })
+
+    return result
+}
+
+// https://unicodelookup.com/ — decode \uNNNN ? sequences into their character.
+function decodeUnicodeEscapes(input: string): string {
+    let result = input
+    let position = result.indexOf("\\u")
+    while (position > -1) {
+        const end = result.indexOf(" ?", position) + 2
+
+        if (end > 1 && end - position <= 10) {
+            const decoded = String.fromCharCode(Number(result.slice(position, end).replace(/[^\d-]/g, "")))
+            if (!decoded.includes("\\x")) result = result.slice(0, position) + decoded + result.slice(end)
+        }
+
+        position = result.indexOf("\\u", position + 1)
+    }
+    return result
+}
+
+function RTFToText(input: string): string {
     // Handle the binary ending characters that sometimes appear
     const binaryEndPos = input.search(/[ÿ¿\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\xFF]+$/)
-    if (binaryEndPos > -1) {
-        input = input.slice(0, binaryEndPos)
-    }
+    if (binaryEndPos > -1) input = input.slice(0, binaryEndPos)
 
     // Remove the last } if it exists
     input = input.slice(0, input.lastIndexOf("}") > 0 ? input.lastIndexOf("}") : input.length)
 
-    // Convert common RTF commands to line breaks
+    // Convert common RTF commands to line breaks.
     input = input.replaceAll("\\pard", "\\remove")
     input = input.replaceAll("\\part", "\\remove")
     input = input.replaceAll("\\par", "__BREAK__")
@@ -459,139 +500,146 @@ function RTFToText(input: string) {
 
     // https://stackoverflow.com/a/188877
     const regex = /\{\*?\\[^{}]+}|[{}]|\\\n?[A-Za-z]+\n?(?:-?\d+)?[ ]?/gm
-    let newInput = input.replace(regex, "").replaceAll("\\*", "")
+    let cleaned = input.replace(regex, "").replaceAll("\\*", "")
 
-    // some files have {} wrapped around the text, so it gets removed
-    if (!newInput.replaceAll("__BREAK__", "").trim().length) {
+    // Some files wrap the text in {} — strip and try again if nothing survived.
+    if (!cleaned.replaceAll("__BREAK__", "").trim().length) {
         input = input.replaceAll("}", "").replaceAll("{", "")
-        newInput = input.replace(regex, "").replaceAll("\\*", "")
+        cleaned = input.replace(regex, "").replaceAll("\\*", "")
 
-        const formatting = newInput.lastIndexOf(";;;;")
-        if (formatting >= 0) newInput = newInput.slice(formatting + 4)
+        const formatting = cleaned.lastIndexOf(";;;;")
+        if (formatting >= 0) cleaned = cleaned.slice(formatting + 4)
 
-        newInput = newInput.replaceAll(";;", "")
+        cleaned = cleaned.replaceAll(";;", "")
     }
 
-    // Clean up remaining formatting artifacts
-    newInput = newInput.replace(/\s+/g, " ").trim()
+    cleaned = cleaned.replace(/\s+/g, " ").trim()
 
-    const splitted = newInput.split("__BREAK__").filter((a) => a.trim())
-    return splitted.join("\n").trim()
+    return cleaned.split("__BREAK__").filter((a) => a.trim()).join("\n").trim()
 }
 
-function decodeHex(input: string) {
-    // If input looks like RTF but doesn't contain hex encodings, use RTF parser
-    if (input.includes("\\rtf") && !input.includes("\\'")) {
-        return RTFToText(input)
-    }
+function decodeHex(input: string): string {
+    // If input looks like RTF but doesn't contain hex encodings, use RTF parser.
+    if (input.includes("\\rtf") && !input.includes("\\'")) return RTFToText(input)
 
-    const textStart = input.indexOf("\\ltrch")
-    // remove RTF before text
-    if (textStart > -1) {
-        input = input.slice(input.indexOf(" ", textStart), input.length)
-    } else {
-        // remove main RTF styles
-        let paragraphs: string[] = input.split("\n\n")
-        if (paragraphs[0].includes("rtf")) {
-            paragraphs = paragraphs.slice(1, paragraphs.length)
-            input = paragraphs.join("\n\n")
-            input = input.slice(0, input.length - 1)
-        }
-    }
-
+    input = stripRTFHeader(input)
     input = input.replaceAll("\\\n", "<br>")
+
+    let str = decodeHexBody(input)
+    return cleanDecodedText(str)
+}
+
+function stripRTFHeader(input: string): string {
+    const textStart = input.indexOf("\\ltrch")
+    if (textStart > -1) return input.slice(input.indexOf(" ", textStart), input.length)
+
+    // Remove main RTF styles at the top of the document.
+    let paragraphs = input.split("\n\n")
+    if (paragraphs[0].includes("rtf")) {
+        paragraphs = paragraphs.slice(1)
+        input = paragraphs.join("\n\n")
+        input = input.slice(0, input.length - 1)
+    }
+    return input
+}
+
+function decodeHexBody(input: string): string {
     const hex = input.split("\\'")
     let str = ""
-    hex.map((txt, i) => {
-        const styles: any[] = []
-
-        // fix skipping first word sometimes
+    hex.forEach((txt, i) => {
         txt = txt.replaceAll("\r\n", "")
+
+        // Fix skipping first word: if a line break precedes the paragraph formatting,
+        // discard everything before the break.
         const breakPos = txt.indexOf("\n")
         const lineFormattingPos = txt.indexOf("\\f0")
-        if (breakPos >= 0 && lineFormattingPos >= 0 && lineFormattingPos < breakPos) txt = txt.slice(breakPos, txt.length)
+        if (breakPos >= 0 && lineFormattingPos >= 0 && lineFormattingPos < breakPos) txt = txt.slice(breakPos)
 
-        let styleIndex = txt.indexOf("\\")
-        while (styleIndex >= 0) {
-            let nextSpace = txt.indexOf(" ", styleIndex)
-            if (nextSpace < 1) nextSpace = txt.length
-            styles.push(txt.slice(styleIndex, nextSpace).trim())
-            txt = txt.slice(0, styleIndex) + txt.slice(nextSpace, txt.length)
-            styleIndex = txt.indexOf("\\")
-        }
+        txt = stripInlineStyles(txt)
 
         if (i === 0) str = txt
         else {
             str += String.fromCharCode(parseInt(txt.slice(0, 2), 16))
-            str += txt.slice(2, txt.length)
+            str += txt.slice(2)
         }
     })
-
-    // fix line formatting
-    str = str.replaceAll("}{", "<br>").replaceAll("} {", "<br>").replaceAll("}  {", "<br>").replaceAll("{ }", "")
-    // remove any {{ at the start
-    if (str.indexOf("{{") > -1 && str.indexOf("{{") < 3) str = str.slice(str.indexOf("{{") + 2, str.length)
-    // remove whitespace at start and end
-    str = str.trim()
-    // remove any } and special chars at the end
-    if (str.length - str.lastIndexOf("}") < 3) str = str.slice(0, str.lastIndexOf("}"))
-    // remove whitespace at start and end
-    str = str.trim()
-    // remove breaks at start
-    while (str.indexOf("<br>") === 0) str = str.slice(4, str.length)
     return str
 }
 
-function rgbStringToHex(rgbaString: string) {
-    if (typeof rgbaString !== "string") return ""
-    const [r, g, b, _updatersa]: any = rgbaString.split(" ")
-    // TODO: alpha
-    if (isNaN(r) || isNaN(g) || isNaN(b)) return ""
-
-    return `#${toHex(r * 255)}${toHex(g * 255)}${toHex(b * 255)}`
+function stripInlineStyles(txt: string): string {
+    let styleIndex = txt.indexOf("\\")
+    while (styleIndex >= 0) {
+        let nextSpace = txt.indexOf(" ", styleIndex)
+        if (nextSpace < 1) nextSpace = txt.length
+        txt = txt.slice(0, styleIndex) + txt.slice(nextSpace)
+        styleIndex = txt.indexOf("\\")
+    }
+    return txt
 }
+
+function cleanDecodedText(str: string): string {
+    str = str.replaceAll("}{", "<br>").replaceAll("} {", "<br>").replaceAll("}  {", "<br>").replaceAll("{ }", "")
+
+    // Remove any leading {{ within the first three characters.
+    if (str.indexOf("{{") > -1 && str.indexOf("{{") < 3) str = str.slice(str.indexOf("{{") + 2)
+
+    str = str.trim()
+
+    // Remove trailing } and special chars.
+    if (str.length - str.lastIndexOf("}") < 3) str = str.slice(0, str.lastIndexOf("}"))
+    str = str.trim()
+
+    while (str.indexOf("<br>") === 0) str = str.slice(4)
+    return str
+}
+
+function rgbStringToHex(rgbaString: string): string {
+    if (typeof rgbaString !== "string") return ""
+    // TODO: honor alpha
+    const [r, g, b]: string[] = rgbaString.split(" ")
+    if (isNaN(+r) || isNaN(+g) || isNaN(+b)) return ""
+
+    return `#${toHex(+r * 255)}${toHex(+g * 255)}${toHex(+b * 255)}`
+}
+
 const toHex = (c: number) => ("0" + Number(c.toFixed()).toString(16)).slice(-2)
 
-/// // PRO 7 /////
+// ----- Pro7 (JSON) -----
 
-function convertProToSlides(song: any) {
-    const slides: any = {}
-    const media: any = {}
-    const layouts: any = []
+function convertProToSlides(song: any): ConvertedShow {
+    const slides: Record<string, Slide> = {}
+    const media: Record<string, any> = {}
+    const layouts: any[] = []
+    const tempLayouts: Record<string, SlideData> = {}
+    const idMap = new Map<string, string>()
 
-    // console.log(song)
-
-    const tempLayouts: any = {}
-    const tempArrangements: any[] = getArrangements(song.arrangements || [])
-    const tempGroups: any[] = getGroups(song.cueGroups || [])
-    const tempSlides: any[] = getSlides(song.cues || [])
-    // console.log(tempArrangements, tempGroups, tempSlides)
-
-    let idMap = new Map<string, string>()
+    const tempSlides = getSlides(song.cues || [])
+    const tempGroups = getGroups(song.cueGroups || [])
+    const tempArrangements = getArrangements(song.arrangements || [])
 
     if (!tempArrangements.length) {
         tempArrangements.push({ groups: Object.keys(tempGroups), name: "" })
     }
 
-    const slidesWithoutGroup = Object.keys(tempSlides).filter((id) => !Object.values(tempGroups).find((a) => a.slides.includes(id)))
-    if (slidesWithoutGroup.length) slidesWithoutGroup.forEach((id) => createSlide(id))
+    // Slides not referenced by any group still need to exist in `tempLayouts`
+    // so id lookups (e.g., from the timeline) resolve.
+    const slidesWithoutGroup = Object.keys(tempSlides).filter((id) => !Object.values(tempGroups).find((g: any) => g.slides.includes(id)))
+    slidesWithoutGroup.forEach((id) => createSlide(id))
 
-    tempArrangements.forEach(createLayout)
-    function createLayout({ name = "", groups: arrGroups }: any) {
-        layouts.push({ id: uid(), name, notes: "", slides: createSlides(arrGroups) })
-    }
+    tempArrangements.forEach(({ name = "", groups: arrGroups }: any) => {
+        layouts.push({ id: uid(), name, notes: "", slides: createLayoutSlides(arrGroups) })
+    })
 
-    function createSlides(arrGroups: string[]) {
-        const layoutSlides: any[] = []
+    function createLayoutSlides(arrGroups: string[]): SlideData[] {
+        const layoutSlides: SlideData[] = []
 
         arrGroups.forEach((groupId) => {
             const group = tempGroups[groupId]
             if (!group) return
 
-            const allSlides = group.slides.map((id, i) => createSlide(id, i === 0, { color: group.color, name: group.name }))
+            const allSlides = group.slides.map((id: string, i: number) => createSlide(id, i === 0, { color: group.color, name: group.name }))
             if (allSlides.length > 1) {
-                const children = allSlides.slice(1).map(({ id }) => id)
-                slides[allSlides[0].id].children = children
+                slides[allSlides[0].id].children = allSlides.slice(1).map(({ id }: SlideData) => id)
             }
 
             layoutSlides.push(allSlides[0])
@@ -600,7 +648,7 @@ function convertProToSlides(song: any) {
         return layoutSlides
     }
 
-    function createSlide(id: string, isParent = true, { color, name }: any = {}) {
+    function createSlide(id: string, isParent = true, { color, name }: { color?: string; name?: string } = {}): SlideData {
         if (tempLayouts[id]) return tempLayouts[id]
 
         const slideId = uid()
@@ -633,7 +681,7 @@ function convertProToSlides(song: any) {
             const group = name || tempSlide.name || ""
             const globalGroup = getGlobalGroup(group)
             slide.color = color || ""
-            slide.group = group || ""
+            slide.group = group
             if (globalGroup) slide.globalGroup = globalGroup
         }
 
@@ -642,87 +690,81 @@ function convertProToSlides(song: any) {
         return layoutSlide
     }
 
-    // TIMELINE
-    const timelineCues = song.timeline?.cues || []
-    if (timelineCues.length) {
-        let slideIndexMap: string[] = []
-        layouts[0].slides.forEach((slide) => {
-            slideIndexMap.push(slide.id)
-            if (slides[slide.id].children) slideIndexMap.push(...(slides[slide.id].children || []))
-        })
-        let currentIndex = -1
-
-        const timeline: Timeline = {
-            actions: timelineCues
-                .map((cue) => {
-                    const id = idMap.get(cue.cueId?.string) || cue.cueId?.string
-                    if (!id) return null
-
-                    let slideIndex = slideIndexMap.findIndex((slideId, i) => slideId === id && i >= currentIndex)
-                    if (slideIndex === -1) slideIndex = slideIndexMap.findIndex((slideId) => slideId === id)
-                    currentIndex = slideIndex
-
-                    return {
-                        id: uid(6),
-                        time: (cue.triggerTime || 0) * 1000,
-                        name: cue.name || "",
-                        type: "slide",
-                        data: {
-                            id,
-                            index: slideIndex > -1 ? slideIndex : undefined
-                        }
-                    }
-                })
-                .filter(Boolean)
-        }
-
-        layouts[0].timeline = timeline
-    }
+    const timeline = buildTimeline(song.timeline?.cues || [], layouts, slides, idMap)
+    if (timeline) layouts[0].timeline = timeline
 
     return { slides, layouts, media }
 }
 
-function convertItem(item: any) {
-    const text = item.text
-    let style = DEFAULT_ITEM_STYLE
-    if (item.bounds) {
-        const pos = item.bounds.origin
-        const size = item.bounds.size
-        if (Object.keys(pos).length === 2 && Object.keys(size).length === 2) {
-            style = `left:${pos.x}px;top:${pos.y}px;width:${size.width}px;height:${size.height}px;`
-        }
-    }
+function buildTimeline(cues: any[], layouts: any[], slides: Record<string, Slide>, idMap: Map<string, string>): Timeline | null {
+    if (!cues.length || !layouts[0]) return null
 
-    const newItem: Item = {
-        style,
-        lines: text.split("\n").map(getLine)
-    }
-
-    return newItem
-
-    function getLine(lineText: string) {
-        return { align: "", text: [{ value: lineText, style: "" }] }
-    }
-}
-
-function getArrangements(arrangements: any) {
-    if (!Array.isArray(arrangements)) return []
-
-    const newArrangements: any = []
-    arrangements.forEach((arr) => {
-        newArrangements.push({
-            name: arr.name,
-            groups: arr.groupIdentifiers?.map((a: any) => a.string) || []
-        })
+    const slideIndexMap: string[] = []
+    layouts[0].slides.forEach((slide: SlideData) => {
+        slideIndexMap.push(slide.id)
+        if (slides[slide.id].children) slideIndexMap.push(...(slides[slide.id].children || []))
     })
 
-    return newArrangements.filter((a: any) => a.groups.length)
+    let currentIndex = -1
+    const actions = cues
+        .map((cue) => {
+            const id = idMap.get(cue.cueId?.string) || cue.cueId?.string
+            if (!id) return null
+
+            // Prefer the next occurrence at or after the current playhead so that
+            // repeated slides on the timeline stay in order.
+            let slideIndex = slideIndexMap.findIndex((slideId, i) => slideId === id && i >= currentIndex)
+            if (slideIndex === -1) slideIndex = slideIndexMap.findIndex((slideId) => slideId === id)
+            currentIndex = slideIndex
+
+            return {
+                id: uid(6),
+                time: (cue.triggerTime || 0) * 1000,
+                name: cue.name || "",
+                type: "slide",
+                data: {
+                    id,
+                    index: slideIndex > -1 ? slideIndex : undefined
+                }
+            }
+        })
+        .filter(Boolean)
+
+    return { actions } as Timeline
 }
 
-function getGroups(cueGroups: any) {
+function convertItem(item: any): Item {
+    return {
+        style: getItemStyle(item),
+        lines: (item.text as string).split("\n").map((lineText) => ({ align: "", text: [{ value: lineText, style: "" }] }))
+    }
+}
+
+function getItemStyle(item: any): string {
+    const bounds = item.bounds
+    if (!bounds) return DEFAULT_ITEM_STYLE
+
+    const { origin: pos, size } = bounds
+    if (Object.keys(pos).length !== 2 || Object.keys(size).length !== 2) return DEFAULT_ITEM_STYLE
+
+    return `left:${pos.x}px;top:${pos.y}px;width:${size.width}px;height:${size.height}px;`
+}
+
+function getArrangements(arrangements: any): any[] {
+    if (!Array.isArray(arrangements)) return []
+
+    return arrangements
+        .map((arr) => ({
+            name: arr.name,
+            groups: arr.groupIdentifiers?.map((a: any) => a.string) || []
+        }))
+        .filter((a) => a.groups.length)
+}
+
+function getGroups(cueGroups: any): Record<string, any> {
     if (!Array.isArray(cueGroups)) return {}
 
-    const newGroups: any = {}
+    const newGroups: Record<string, any> = {}
     cueGroups.forEach(({ group, cueIdentifiers }: any) => {
         newGroups[group.uuid.string] = {
             name: group.name,
@@ -734,8 +776,8 @@ function getGroups(cueGroups: any) {
     return newGroups
 }
 
-function getSlides(cues: any) {
-    const slides: any = {}
+function getSlides(cues: any): Record<string, any> {
+    const slides: Record<string, any> = {}
     if (!Array.isArray(cues)) return slides
 
     cues.forEach((slide: any) => {
@@ -749,7 +791,6 @@ function getSlides(cues: any) {
             backgroundColor: getColorValue(baseSlide.backgroundColor),
             size: baseSlide.size,
             items: baseSlide.elements?.map(getItem) || []
-            // .filter((a) => a.text || a.bounds?.size?.width)
         }
     })
 
@@ -757,33 +798,26 @@ function getSlides(cues: any) {
 }
 
 function getItem(item: any) {
-    const newItem: any = {}
-
-    newItem.bounds = item.element.bounds
-    newItem.text = decodeRTF(item.element.text?.rtfData)
-
-    return newItem
+    return {
+        bounds: item.element.bounds,
+        text: decodeRTF(item.element.text?.rtfData)
+    }
 }
 
-function decodeRTF(text: string) {
+function decodeRTF(text: string): string {
     if (!text) return ""
-
-    text = decodeBase64(text)
-    // console.log(text)
-    text = RTFToText(text)
-    // console.log(text)
-    return text
+    return RTFToText(decodeBase64(text))
 }
 
-function getColorValue(color: { red: number; green: number; blue: number; alpha: number }) {
+function getColorValue(color: { red: number; green: number; blue: number; alpha: number }): string {
     if (!color) return ""
 
-    color = {
+    const rgba = {
         red: color.red || 255,
         green: color.green || 255,
         blue: color.blue || 255,
         alpha: color.alpha || 1
     }
 
-    return "rgb(" + [color.red.toFixed(2), color.green.toFixed(2), color.blue.toFixed(2)].join(" ") + " / " + color.alpha.toFixed(1) + ")"
+    return `rgb(${rgba.red.toFixed(2)} ${rgba.green.toFixed(2)} ${rgba.blue.toFixed(2)} / ${rgba.alpha.toFixed(1)})`
 }

--- a/src/frontend/utils/chordTranspose.test.ts
+++ b/src/frontend/utils/chordTranspose.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest"
+import { transposeText } from "./chordTranspose"
+
+// transposeText looks for chord tokens in [brackets] and transposes them by `step` semitones.
+// Anything that doesn't look like a chord (e.g. section labels [Verse], [Chorus]) is left alone.
+
+describe("transposeText — basic transposition", () => {
+    it("shifts a root chord up by one semitone (sharp preferred going up)", () => {
+        expect(transposeText("[C]", 1)).toBe("[C#]")
+        expect(transposeText("[G]", 2)).toBe("[A]")
+    })
+    it("shifts a root chord down by one semitone (flat preferred going down)", () => {
+        expect(transposeText("[C]", -1)).toBe("[B]")
+        expect(transposeText("[D]", -1)).toBe("[Db]")
+    })
+    it("preserves quality/extension suffixes when transposing", () => {
+        expect(transposeText("[Cmaj7]", 2)).toBe("[Dmaj7]")
+        expect(transposeText("[Am7]", 2)).toBe("[Bm7]")
+        expect(transposeText("[Gsus4]", 5)).toBe("[Csus4]")
+    })
+    it("wraps around the octave (+12 = same chord)", () => {
+        expect(transposeText("[C]", 12)).toBe("[C]")
+        expect(transposeText("[C]", -12)).toBe("[C]")
+    })
+})
+
+describe("transposeText — slash chords", () => {
+    it("transposes both the main and bass note", () => {
+        expect(transposeText("[C/G]", 2)).toBe("[D/A]")
+    })
+    it("handles minor + bass together", () => {
+        expect(transposeText("[Bm7/E]", 1)).toBe("[Cm7/F]")
+    })
+})
+
+describe("transposeText — accidentals in and out", () => {
+    it("accepts unicode ♯ / ♭ symbols in the input and normalizes them", () => {
+        expect(transposeText("[C♯]", 1)).toBe("[D]")
+        expect(transposeText("[D♭]", 1)).toBe("[D]") // Db up 1 = D
+    })
+    it("prefers sharps when transposing up", () => {
+        expect(transposeText("[C]", 1)).toBe("[C#]")
+    })
+    it("prefers flats when transposing down", () => {
+        expect(transposeText("[D]", -1)).toBe("[Db]")
+    })
+})
+
+describe("transposeText — inline text", () => {
+    it("only touches text inside brackets, not surrounding lyrics", () => {
+        const input = "Amazing [G]grace how [C]sweet the [D]sound"
+        expect(transposeText(input, 2)).toBe("Amazing [A]grace how [D]sweet the [E]sound")
+    })
+    it("leaves section labels like [Verse] / [Chorus] untouched", () => {
+        // "Verse" starts with V — not a valid root; there is also the length + word heuristic
+        expect(transposeText("[Verse]\n[Chorus]\n[Bridge]", 2)).toBe("[Verse]\n[Chorus]\n[Bridge]")
+    })
+    it("leaves plain text with no bracketed tokens unchanged", () => {
+        expect(transposeText("no chords here", 5)).toBe("no chords here")
+    })
+})
+
+describe("transposeText — no-op step", () => {
+    it("returns the input unchanged for step=0", () => {
+        // step 0 with sharps preferred; C stays C, C# stays C#
+        expect(transposeText("[C] [G] [Am]", 0)).toBe("[C] [G] [Am]")
+    })
+})

--- a/src/frontend/utils/common.test.ts
+++ b/src/frontend/utils/common.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+
+// common.ts pulls in stores, IPC, and cross-module helpers we don't need. Stub them all —
+// the target functions (throttle, hasNewerUpdate, wait) don't actually touch any of them.
+vi.mock("../stores", () => {
+    const makeStore = (initial: unknown = null) => {
+        let value = initial
+        return {
+            _set: (v: unknown) => (value = v),
+            set: (v: unknown) => (value = v),
+            subscribe: (fn: (v: unknown) => void) => (fn(value), () => {})
+        }
+    }
+    return {
+        activePopup: makeStore(""),
+        activeTriggerFunction: makeStore(""),
+        autosave: makeStore("15min"),
+        currentWindow: makeStore(null),
+        disabledServers: makeStore({}),
+        drawer: makeStore({ height: 0, stored: null }),
+        errorHasOccurred: makeStore(false),
+        focusedArea: makeStore(""),
+        os: makeStore({ platform: "test" }),
+        outputs: makeStore({}),
+        quickSearchActive: makeStore(false),
+        resized: makeStore({ leftPanel: 0, rightPanel: 0 }),
+        serverData: makeStore({}),
+        statusIndicator: makeStore(""),
+        theme: makeStore("light"),
+        themes: makeStore({}),
+        toastMessages: makeStore([]),
+        version: makeStore("test")
+    }
+})
+vi.mock("../components/helpers/output", () => ({ getActiveOutputs: () => [], toggleOutputs: () => {} }))
+vi.mock("../IPC/main", () => ({ sendMain: () => {} }))
+vi.mock("./request", () => ({ send: () => {} }))
+vi.mock("./save", () => ({ save: () => {} }))
+vi.mock("../values/autosave", () => ({ convertAutosave: {} }))
+// keep the real array/color helpers — they're small and used by common's public surface
+
+import { hasNewerUpdate, throttle, wait } from "./common"
+
+describe("wait", () => {
+    it("resolves with 'ended' after the requested delay", async () => {
+        const result = await wait(10)
+        expect(result).toBe("ended")
+    })
+})
+
+describe("throttle", () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it("invokes the callback synchronously on the first call for a given id", () => {
+        const cb = vi.fn()
+        throttle("t1", 1, cb, 10)
+        expect(cb).toHaveBeenCalledTimes(1)
+        expect(cb).toHaveBeenCalledWith(1)
+    })
+
+    it("swallows rapid-fire calls in the same window, then emits the latest value on the trailing edge", () => {
+        const cb = vi.fn()
+        throttle("t2", 1, cb, 10) // fires immediately with 1
+        throttle("t2", 2, cb, 10) // held
+        throttle("t2", 3, cb, 10) // held (only the latest survives)
+        expect(cb).toHaveBeenCalledTimes(1)
+
+        vi.advanceTimersByTime(1000 / 10) // 100ms window elapses
+        // trailing call fires with the most recent value
+        expect(cb).toHaveBeenCalledTimes(2)
+        expect(cb).toHaveBeenLastCalledWith(3)
+    })
+
+    it("does NOT emit a trailing call if nothing new arrived during the throttle window", () => {
+        const cb = vi.fn()
+        throttle("t3", "only", cb, 10) // fires immediately
+        vi.advanceTimersByTime(1000 / 10)
+        // no queued update, so no trailing emission
+        expect(cb).toHaveBeenCalledTimes(1)
+    })
+
+    it("uses separate windows per id", () => {
+        const cb1 = vi.fn()
+        const cb2 = vi.fn()
+        throttle("A", 1, cb1, 10)
+        throttle("B", 2, cb2, 10)
+        expect(cb1).toHaveBeenCalledWith(1)
+        expect(cb2).toHaveBeenCalledWith(2)
+    })
+})
+
+describe("hasNewerUpdate", () => {
+    beforeEach(() => vi.useFakeTimers())
+    afterEach(() => vi.useRealTimers())
+
+    it("resolves false after the timeout when no newer call comes in", async () => {
+        const p = hasNewerUpdate("only", 50)
+        vi.advanceTimersByTime(60)
+        await expect(p).resolves.toBe(false)
+    })
+
+    it("resolves true on the OLD promise when a newer call arrives for the same id (supersedes)", async () => {
+        const first = hasNewerUpdate("same-id", 100)
+        const second = hasNewerUpdate("same-id", 100) // the new one preempts the first
+
+        await expect(first).resolves.toBe(true) // superseded
+        vi.advanceTimersByTime(120)
+        await expect(second).resolves.toBe(false) // and the new one gets to finish
+    })
+
+    it("keeps ids independent (a newer update on one id doesn't preempt another)", async () => {
+        const a = hasNewerUpdate("id-A", 50)
+        const b = hasNewerUpdate("id-B", 50)
+        vi.advanceTimersByTime(60)
+        await expect(a).resolves.toBe(false)
+        await expect(b).resolves.toBe(false)
+    })
+})

--- a/src/frontend/utils/search.tokenize.test.ts
+++ b/src/frontend/utils/search.tokenize.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, vi } from "vitest"
+
+// tokenize + isRefinement are pure; formatSearch is already covered from another angle in search.test.ts.
+// Mock the same collaborator surface that search.test.ts does so importing search.ts here doesn't
+// try to reach into svelte stores or txt.ts.
+const h = vi.hoisted(() => {
+    const makeStore = (initial: unknown) => {
+        let value = initial
+        return { _set: (v: unknown) => (value = v), subscribe: (fn: (v: unknown) => void) => (fn(value), () => {}) }
+    }
+    return { textCache: makeStore({}), categories: makeStore({}), drawerTabsData: makeStore({}) }
+})
+vi.mock("../stores", () => ({ textCache: h.textCache, categories: h.categories, drawerTabsData: h.drawerTabsData }))
+vi.mock("../components/helpers/array", () => ({
+    sortObjectNumbers: (arr: any[], key: string, desc = false) => [...arr].sort((a, b) => (desc ? (b[key] || 0) - (a[key] || 0) : (a[key] || 0) - (b[key] || 0)))
+}))
+vi.mock("../converters/txt", () => ({ similarity: () => 0 }))
+
+import { isRefinement, tokenize } from "./search"
+
+describe("tokenize", () => {
+    it("splits on whitespace and lowercases", () => {
+        expect(tokenize("Amazing Grace")).toEqual(["amazing", "grace"])
+    })
+    it("collapses runs of whitespace and skips empty tokens", () => {
+        expect(tokenize("   how   great   thou   art   ")).toEqual(["how", "great", "thou", "art"])
+    })
+    it("returns an empty array for an empty or whitespace-only string", () => {
+        expect(tokenize("")).toEqual([])
+        expect(tokenize("   \t \n ")).toEqual([])
+    })
+    it("does not touch punctuation (that's formatSearch's job)", () => {
+        expect(tokenize("hello, world!")).toEqual(["hello,", "world!"])
+    })
+})
+
+describe("isRefinement", () => {
+    // A refinement means the new query is 'the old query plus more' — so any full-token match should
+    // benefit from cached results without re-running the full search.
+    it("returns true when every old token still appears in the new tokens", () => {
+        expect(isRefinement(["amazing", "grace", "sweet"], ["amazing", "grace"])).toBe(true)
+    })
+    it("returns false when an old token is missing (user broadened / changed the query)", () => {
+        expect(isRefinement(["amazing"], ["amazing", "grace"])).toBe(false)
+    })
+    it("returns false when there is nothing to refine yet (first search)", () => {
+        // by contract this is 'not a refinement' — the caller should still do a full search
+        expect(isRefinement(["amazing"], [])).toBe(false)
+    })
+    it("is a subset check, not order-sensitive", () => {
+        expect(isRefinement(["grace", "amazing"], ["amazing", "grace"])).toBe(true)
+    })
+})


### PR DESCRIPTION
Since I think the test coverage for this project is a bit sad, I was motivated to add some tests....

Adds 9 test files covering ~160 new tests across the frontend and electron utility layers. Suite grows from 37 → 199 tests, all passing.

Frontend helpers (src/frontend/components/helpers/):
- array.test.ts     — sort/move/dedup/select helpers, defensive guards
- bytes.test.ts     — formatBytes across all size tiers
- color.test.ts     — hex/rgb/hsl round-trip, gradient parsing, contrast
- style.test.ts     — getStyles / getFilters / removeText
- time.test.ts      — secondsToTime, joinTime, timeAgo, date formatting

Frontend utils (src/frontend/utils/):
- chordTranspose.test.ts     — transposeText with slash chords, unicode,
                                sharp/flat preference, section labels
- common.test.ts             — throttle (leading + trailing edge),
                                hasNewerUpdate (superseding semantics), wait
- search.tokenize.test.ts    — tokenize + isRefinement

Electron helpers (src/electron/utils/):
- helpers.test.ts   — clone, checkIfMatching, wait, waitUntilValueIsDefined

Follows the mocking pattern established by the existing syncLedger and search tests — stub svelte stores / IPC modules; keep pure collaborators real. All files prettier-clean.