### PR TITLE
Fix audio playlist stopping after one song

### DIFF
--- a/src/frontend/audio/audioFading.ts
+++ b/src/frontend/audio/audioFading.ts
@@ -20,7 +20,7 @@ export const clearing: string[] = []
 let forceClear = false
 export function clearAudio(audioPath = "", options: AudioClearOptions = {}) {
     // turn off any playlist
-    if (options.clearPlaylist && (!audioPath || AudioPlaylist.getPlayingPath() === audioPath)) activePlaylist.set(null)
+    if (options.clearPlaylist && (!audioPath || AudioPlaylist.getPlayingKey() === audioPath)) activePlaylist.set(null)
 
     // stop playing metronome
     if (!options.isPlayingNew && options.clearPlaylist !== false && !audioPath) stopMetronome()

--- a/src/frontend/audio/audioPlayer.ts
+++ b/src/frontend/audio/audioPlayer.ts
@@ -6,7 +6,7 @@ import { customActionActivation } from "../components/actions/actions"
 import { encodeFilePath, getFileName, locateMediaFile, removeExtension } from "../components/helpers/media"
 import { checkNextAfterMedia } from "../components/helpers/showActions"
 import { requestMain, sendMain } from "../IPC/main"
-import { audioChannelsData, dictionary, media, outLocked, playingAudio, playingAudioPaths, special, volume } from "../stores"
+import { activePlaylist, audioChannelsData, dictionary, media, outLocked, playingAudio, playingAudioPaths, special, volume } from "../stores"
 import { addToMediaFolder } from "../utils/cloudSync"
 import { AudioAnalyser } from "./audioAnalyser"
 import { AudioAnalyserMerger } from "./audioAnalyserMerger"
@@ -60,14 +60,25 @@ export class AudioPlayer {
 
     // INIT
 
-    static async start(path: string, metadata: AudioMetadata, options: AudioOptions = {}) {
-        if (get(outLocked) || clearing.includes(path) || this.isLoading(path)) return
-        this.setLoading(path)
+    /** returns false when the audio file could not be found or loaded */
+    static async start(path: string, metadata: AudioMetadata, options: AudioOptions = {}): Promise<boolean> {
+        if (get(outLocked) || clearing.includes(path) || this.isLoading(path)) return true
+        const requestedPath = path
+        this.setLoading(requestedPath)
 
         const located = await locateMediaFile(path)
         if (!located) {
-            this.clearLoading(path)
-            return
+            this.clearLoading(requestedPath)
+            return false
+        }
+
+        // playlist songs are tracked by their stored path - remember the actual path if the file resolved somewhere else,
+        // so playlist checks (auto next/crossfade) still recognize the playing audio
+        if (located.path !== path && get(activePlaylist)?.active === path) {
+            activePlaylist.update((a) => {
+                if (a) a.activeKey = located.path
+                return a
+            })
         }
 
         path = located.path
@@ -81,19 +92,19 @@ export class AudioPlayer {
         if (this.audioExists(path)) {
             if (options.pauseIfPlaying === false) {
                 updateAudioStore(path, "currentTime", 0)
-                this.clearLoading(path)
-                return
+                this.clearLoading(requestedPath)
+                return true
             }
             if (options.stopIfPlaying) {
                 if (options.clearTime) clearAudio(path, { clearTime: options.clearTime })
                 else AudioPlayer.stop(path)
-                this.clearLoading(path)
-                return
+                this.clearLoading(requestedPath)
+                return true
             }
 
             this.togglePausedState(path)
-            this.clearLoading(path)
-            return
+            this.clearLoading(requestedPath)
+            return true
         }
 
         const audioPlaying = Object.keys(get(playingAudio)).length
@@ -101,10 +112,14 @@ export class AudioPlayer {
         else if (!options.playMultiple) clearAudio("", { playlistCrossfade: options.playlistCrossfade, isPlayingNew: true })
 
         const audio = await this.createAudio(path)
+        if (!audio) {
+            this.clearLoading(requestedPath)
+            return false
+        }
         // another audio might have been started while awaiting (if played rapidly)
-        if (!audio || this.audioExists(path)) {
-            this.clearLoading(path)
-            return
+        if (this.audioExists(path)) {
+            this.clearLoading(requestedPath)
+            return true
         }
 
         let replayGainMultiplier = 1
@@ -145,7 +160,8 @@ export class AudioPlayer {
 
         const name = removeExtension(metadata.name || getFileName(path))
         this.nowPlaying(path, name)
-        this.clearLoading(path)
+        this.clearLoading(requestedPath)
+        return true
     }
 
     static async playStream(id: string, stream: MediaStream, metadata: AudioMetadata) {
@@ -307,7 +323,7 @@ export class AudioPlayer {
             let newVolume = this.getVolume(id)
 
             // check playlist volume
-            if (AudioPlaylist.getPlayingPath() === id) {
+            if (AudioPlaylist.getPlayingKey() === id) {
                 newVolume *= AudioPlaylist.getActivePlaylist()?.volume || 1
             }
 
@@ -360,7 +376,8 @@ export class AudioPlayer {
             return
         }
 
-        if (AudioPlaylist.getPlayingPath() === id) {
+        // compare with the playing key as the playlist path might have resolved to a different file path
+        if (AudioPlaylist.getPlayingKey() === id) {
             this.stop(id) // stop existing
             AudioPlaylist.next(true)
             return

--- a/src/frontend/audio/audioPlayer.ts
+++ b/src/frontend/audio/audioPlayer.ts
@@ -60,20 +60,19 @@ export class AudioPlayer {
 
     // INIT
 
-    /** returns false when the audio file could not be found or loaded */
+    // returns false when the audio file can't be found or loaded
     static async start(path: string, metadata: AudioMetadata, options: AudioOptions = {}): Promise<boolean> {
         if (get(outLocked) || clearing.includes(path) || this.isLoading(path)) return true
-        const requestedPath = path
-        this.setLoading(requestedPath)
+        const pathId = path
+        this.setLoading(pathId)
 
         const located = await locateMediaFile(path)
         if (!located) {
-            this.clearLoading(requestedPath)
+            this.clearLoading(pathId)
             return false
         }
 
-        // playlist songs are tracked by their stored path - remember the actual path if the file resolved somewhere else,
-        // so playlist checks (auto next/crossfade) still recognize the playing audio
+        // update active playlist file if it's located to a new path
         if (located.path !== path && get(activePlaylist)?.active === path) {
             activePlaylist.update((a) => {
                 if (a) a.activeKey = located.path
@@ -92,18 +91,18 @@ export class AudioPlayer {
         if (this.audioExists(path)) {
             if (options.pauseIfPlaying === false) {
                 updateAudioStore(path, "currentTime", 0)
-                this.clearLoading(requestedPath)
+                this.clearLoading(pathId)
                 return true
             }
             if (options.stopIfPlaying) {
                 if (options.clearTime) clearAudio(path, { clearTime: options.clearTime })
                 else AudioPlayer.stop(path)
-                this.clearLoading(requestedPath)
+                this.clearLoading(pathId)
                 return true
             }
 
             this.togglePausedState(path)
-            this.clearLoading(requestedPath)
+            this.clearLoading(pathId)
             return true
         }
 
@@ -113,12 +112,12 @@ export class AudioPlayer {
 
         const audio = await this.createAudio(path)
         if (!audio) {
-            this.clearLoading(requestedPath)
+            this.clearLoading(pathId)
             return false
         }
         // another audio might have been started while awaiting (if played rapidly)
         if (this.audioExists(path)) {
-            this.clearLoading(requestedPath)
+            this.clearLoading(pathId)
             return true
         }
 
@@ -160,7 +159,7 @@ export class AudioPlayer {
 
         const name = removeExtension(metadata.name || getFileName(path))
         this.nowPlaying(path, name)
-        this.clearLoading(requestedPath)
+        this.clearLoading(pathId)
         return true
     }
 
@@ -376,7 +375,6 @@ export class AudioPlayer {
             return
         }
 
-        // compare with the playing key as the playlist path might have resolved to a different file path
         if (AudioPlaylist.getPlayingKey() === id) {
             this.stop(id) // stop existing
             AudioPlaylist.next(true)

--- a/src/frontend/audio/audioPlaylist.ts
+++ b/src/frontend/audio/audioPlaylist.ts
@@ -13,6 +13,7 @@ type PlaylistData = {
     crossfade?: number
     loop?: boolean
     autoNext?: boolean
+    skipAttempts?: number // songs skipped in a row because their file could not be played
 }
 
 export class AudioPlaylist {
@@ -60,8 +61,14 @@ export class AudioPlaylist {
         AudioPlaylist.nextInternal("", -1, { crossfade, loop: playlist.loop !== false, autoNext: isEnding ? playlist.autoNext !== false : true })
     }
 
+    // the song path as stored in the playlist (used to find the position in the song list)
     static getPlayingPath(): string {
         return get(activePlaylist)?.active || ""
+    }
+
+    // the actually playing file path - can differ from the stored path when a moved file is auto-located
+    static getPlayingKey(): string {
+        return get(activePlaylist)?.activeKey || AudioPlaylist.getPlayingPath()
     }
 
     static getActivePlaylist() {
@@ -73,7 +80,7 @@ export class AudioPlaylist {
 
     private static isCrossfading = false
     static checkCrossfade() {
-        const audioPath = AudioPlaylist.getPlayingPath()
+        const audioPath = AudioPlaylist.getPlayingKey()
         if (isAllAudioFading || !audioPath || get(media)[audioPath]?.loop) {
             this.isCrossfading = false
             return
@@ -93,7 +100,7 @@ export class AudioPlaylist {
         if (!playlist) return 0
 
         const crossfade = Number(playlist.crossfade) || 0
-        const audioPath = AudioPlaylist.getPlayingPath()
+        const audioPath = AudioPlaylist.getPlayingKey()
         const playing = AudioPlayer.getAudio(audioPath)
         if (!crossfade || !audioPath || !playing) return 0
 
@@ -106,7 +113,7 @@ export class AudioPlaylist {
         return crossfade
     }
 
-    protected static nextInternal(audioPath = "", startIndex = -1, data: PlaylistData) {
+    protected static async nextInternal(audioPath = "", startIndex = -1, data: PlaylistData) {
         const playlist = clone(AudioPlaylist.getActivePlaylist())
         if (!playlist) return
 
@@ -131,7 +138,7 @@ export class AudioPlaylist {
         }
 
         // prevent playing the same song twice (while it's fading) to stop duplicate audio
-        if (Object.keys(playingAudio).includes(nextSong)) return
+        if (Object.keys(get(playingAudio)).includes(nextSong)) return
 
         let nextIndex = startIndex > -1 ? startIndex : (get(activePlaylist)?.index ?? -1) + 1
         if (playlist.songs[nextIndex] !== nextSong) nextIndex = songs.findIndex((a) => a === nextSong)
@@ -139,12 +146,21 @@ export class AudioPlaylist {
         activePlaylist.update((a) => {
             if (!a) a = {}
             a.active = nextSong
+            a.activeKey = nextSong // updated by AudioPlayer if the file resolves to a different path
             a.index = nextIndex
             return a
         })
 
         // if (crossfade) isCrossfading = true
-        AudioPlayer.start(nextSong, { name: "" }, { pauseIfPlaying: false, crossfade: data.crossfade, playlistCrossfade: true, startPaused: data.autoNext === false, volume: playlist.volume || 1 })
+        const started = await AudioPlayer.start(nextSong, { name: "" }, { pauseIfPlaying: false, crossfade: data.crossfade, playlistCrossfade: true, startPaused: data.autoNext === false, volume: playlist.volume || 1 })
+
+        // skip songs that can't be played (e.g. moved/deleted files), so one missing file does not stop the playlist
+        if (started === false) {
+            const skipAttempts = (data.skipAttempts || 0) + 1
+            if (skipAttempts >= songs.length) return
+            console.error("Could not play playlist audio, skipping:", nextSong)
+            AudioPlaylist.nextInternal("", -1, { ...data, skipAttempts })
+        }
 
         function getSongs(): string[] {
             if (previousPath && get(activePlaylist)?.songs) return get(activePlaylist).songs

--- a/src/frontend/audio/audioPlaylist.ts
+++ b/src/frontend/audio/audioPlaylist.ts
@@ -13,7 +13,7 @@ type PlaylistData = {
     crossfade?: number
     loop?: boolean
     autoNext?: boolean
-    skipAttempts?: number // songs skipped in a row because their file could not be played
+    cannotPlay?: number // songs skipped in a row because their file could not be played
 }
 
 export class AudioPlaylist {
@@ -61,12 +61,12 @@ export class AudioPlaylist {
         AudioPlaylist.nextInternal("", -1, { crossfade, loop: playlist.loop !== false, autoNext: isEnding ? playlist.autoNext !== false : true })
     }
 
-    // the song path as stored in the playlist (used to find the position in the song list)
+    // the file path as stored in the playlist (used to find the position in the song list)
     static getPlayingPath(): string {
         return get(activePlaylist)?.active || ""
     }
 
-    // the actually playing file path - can differ from the stored path when a moved file is auto-located
+    // the actually playing file path - might be different if auto located to a new path
     static getPlayingKey(): string {
         return get(activePlaylist)?.activeKey || AudioPlaylist.getPlayingPath()
     }
@@ -146,7 +146,7 @@ export class AudioPlaylist {
         activePlaylist.update((a) => {
             if (!a) a = {}
             a.active = nextSong
-            a.activeKey = nextSong // updated by AudioPlayer if the file resolves to a different path
+            a.activeKey = nextSong // might be changed into an auto located path
             a.index = nextIndex
             return a
         })
@@ -155,11 +155,12 @@ export class AudioPlaylist {
         const started = await AudioPlayer.start(nextSong, { name: "" }, { pauseIfPlaying: false, crossfade: data.crossfade, playlistCrossfade: true, startPaused: data.autoNext === false, volume: playlist.volume || 1 })
 
         // skip songs that can't be played (e.g. moved/deleted files), so one missing file does not stop the playlist
-        if (started === false) {
-            const skipAttempts = (data.skipAttempts || 0) + 1
-            if (skipAttempts >= songs.length) return
+        if (!started) {
+            const cannotPlay = (data.cannotPlay || 0) + 1
+            if (cannotPlay >= songs.length) return
+
             console.error("Could not play playlist audio, skipping:", nextSong)
-            AudioPlaylist.nextInternal("", -1, { ...data, skipAttempts })
+            AudioPlaylist.nextInternal("", -1, { ...data, cannotPlay: cannotPlay })
         }
 
         function getSongs(): string[] {


### PR DESCRIPTION
# Branch: `cfix-audio-playlist-next`

**Commit:** `95bdf2cf` (branched from `dev`)

## Summary

Fixes audio playlists **stopping after the first song** (auto play next not working) — reported from the audio panel, playlists dragged into slides, and slide actions alike. Two independent stoppers were found, both tied to songs not playing from their *exact stored path* (increasingly likely with large mp3 libraries where files have been moved or reorganized), plus two latent bugs in the same flow.

| Issue | Root cause | Fix |
|---|---|---|
| Playlist plays one song then stops (reproduced) | Auto-located songs play under a *different path* than the playlist tracks, so end-of-song checks don't recognize them | Playlist records the resolved path (`activeKey`) and all playing-audio checks use it |
| One missing file kills the whole playlist | `AudioPlayer.start` returned silently on load failure; nothing ever advanced | `start()` reports failures; playlist skips to the next playable song |
| Remapped song can't replay on the playlist's second loop | Loading guard tracked the pre-locate path but cleared the resolved path | Guard now clears the requested path |
| Duplicate-song check never worked | Read `Object.keys()` of the store object itself instead of its value | Uses `get(playingAudio)` |

## Deep dive

### How playlist advancement works

When a song ends, the audio element's `ended` event (and a periodic check driven by the audio-analyser loop) calls `AudioPlayer.checkIfEnding`, which decides whether the ended audio belongs to the active playlist:

```ts
// audioPlayer.ts
if (AudioPlaylist.getPlayingPath() === id) {
    this.stop(id)              // stop existing
    AudioPlaylist.next(true)   // advance
    return
}
this.stop(id)                  // ← standalone audio: just stop
```

`AudioPlaylist.nextInternal` picks the next song from the stored list and starts it. Crossfade advancement works similarly, looking up the playing element by the tracked path.

### Bug 1: path remapping breaks recognition (reproduced live)

`AudioPlayer.start` runs every path through auto-locate, which can **resolve a different path** — when the file moved and is found in the media sync folder or via a deep search of registered audio folders:

```ts
const located = await locateMediaFile(path)
path = located.path            // may differ from the playlist's stored path
```

The song then plays under the resolved path, but `activePlaylist.active` keeps the stored path. At song end, `checkIfEnding` compares the playing key against `getPlayingPath()`, gets no match, and treats it as standalone audio: plain stop, no "next". Crossfade breaks identically (`getAudio(active)` returns `null`).

Reproduced against the packaged app: a playlist whose files were moved to a registered audio folder played exactly one song, then went silent.

**Fix** — the playlist records the actually-played path alongside the stored one:

```ts
// audioPlayer.ts — start()
if (located.path !== path && get(activePlaylist)?.active === path) {
    activePlaylist.update((a) => {
        if (a) a.activeKey = located.path
        return a
    })
}

// audioPlaylist.ts
static getPlayingPath(): string {          // stored path → drives song order
    return get(activePlaylist)?.active || ""
}
static getPlayingKey(): string {           // actually playing path → audio element checks
    return get(activePlaylist)?.activeKey || AudioPlaylist.getPlayingPath()
}
```

All playing-audio comparisons (`checkIfEnding`'s playlist branch, crossfade lookup and loop check, playlist volume, playlist-clear detection) now use `getPlayingKey()`, while `nextInternal` keeps using the stored path to find the position in the song list. `activeKey` is reset to the stored path whenever a new song is selected, then updated by `AudioPlayer` if the file resolves elsewhere.

### Bug 2: missing files silently kill the playlist

If the next song's file can't be found at all, auto-locate fails (after a slow 8-level search through every registered folder — which with thousands of files also *looks* like a freeze), and `AudioPlayer.start` just returned. `nextInternal` fired-and-forgot, so the playlist died at that song. With a big library, one renamed/deleted file is all it takes.

**Fix** — `start()` now returns whether the audio could be started, and the playlist skips unplayable songs with a guard against a fully-missing list:

```ts
// audioPlaylist.ts — nextInternal()
const started = await AudioPlayer.start(nextSong, { name: "" }, { ... })

// skip songs that can't be played (e.g. moved/deleted files), so one missing file does not stop the playlist
if (started === false) {
    const skipAttempts = (data.skipAttempts || 0) + 1
    if (skipAttempts >= songs.length) return
    console.error("Could not play playlist audio, skipping:", nextSong)
    AudioPlaylist.nextInternal("", -1, { ...data, skipAttempts })
}
```

`start()` returns `false` only for genuine load failures (locate failed, audio element errored); "already playing / toggled pause" paths return `true` so they're never skipped.

### Bugs 3 & 4: latent issues in the same flow

The loading guard registered the *requested* path but cleared the *resolved* one, so a remapped song stayed "loading" forever and could never start again (breaking the playlist's second loop):

```ts
const requestedPath = path
this.setLoading(requestedPath)
...
this.clearLoading(requestedPath)   // was: this.clearLoading(path) after path = located.path
```

And the duplicate-song guard compared against the Svelte store object's method names instead of its value — it could never match:

```ts
// before: Object.keys(playingAudio).includes(nextSong)      → ["set","update","subscribe"]
if (Object.keys(get(playingAudio)).includes(nextSong)) return
```

## Verification

Verified live against the packaged app through the remote API (playlist seeded, playback observed via polling):

- **Remap scenario**: all files moved to a registered audio folder → previously played one song and stopped; now plays song1 → song2 → song3 and loops.
- **Missing-file scenario**: one file deleted entirely → song1 → *skips the deleted song* → song3 → loops.
- Default scenario (files at stored paths) confirmed unchanged before and after, with both short ("effect"-type) and 35s ("music"-type) files.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
