### PR TITLE
Update bug report template to ask users to test on newest versions stable/beta and check for similar issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,17 @@ labels: bug
 assignees: ''
 
 ---
+<!-- Before filling a bug report please be able to answer the following three questions with a YES (Please delete the No after each question). Failure to do so may result in your bug being closed as a duplicate. This waste the developers time.
+
+This will help to reduce the number of duplicate bug reports and reports for bugs that have already been fixed in newer versions. Please respect our developers time and take the time to check for similar issues and test or the latest stable and beta versions. The lastest versions stable and beta can always be found on the GitHub releases page. https://github.com/ChurchApps/FreeShow/releases -->
+
+<!-- Please search for keywords related to your issue to see if it has already been reported. Do not forget to check the closed issues as it may already have been resolved in a newer release. When searching issues it defaults to showing open issues but at the top will also show you the number of closed issues related to your search. Clicking on "Closed" will switch you to the list of matching closed issues. -->
+
+**Have you searched the FreeShow issues on GitHub (open and closed) for similar or the same issue and not found any matching or similar issues? Yes/No**
+
+**Have you tested and been able to reproduce the bug on the latest stable version? Yes/No** <!-- [e.g. 1.6.3, 1.6.4] -->
+
+**Have you tested and been able to reproduce the bug on the latest beta version? Yes/No** <!-- [e.g. 1.6.3-beta.1, 1.6.4-beta.3] -->
 
 **Describe the bug**
 <!-- A clear and concise description of what the bug is. -->
@@ -17,6 +28,7 @@ assignees: ''
 <!-- If applicable, add screenshots to help explain your problem. -->
 
 **Version (Optional)**
+<!-- If you know that the issues is related to a specific OS please include it here. If you are able to determine in what version of FreeShow the issue started, please include that here and mention it in the description. -->
  - OS: <!-- [Windows/MacOS/Linux] -->
  - FreeShow Version: <!-- [e.g. 1.0.0] -->
 


### PR DESCRIPTION
I have been guilty of forgetting to check these things and have also seen in the issue queue issues being closed  for this reason. [This one for example.](https://github.com/ChurchApps/FreeShow/issues/3491#issuecomment-4935181178)

Hopefully these changes will lessen the number of duplicate and filled-after-being-fixed bug reports.