### PR TITLE
Add per-item toggle for zero-padded dynamic timer values

### DIFF
--- a/public/lang/en.json
+++ b/public/lang/en.json
@@ -1056,6 +1056,7 @@
         "transpose_down": "Transpose down",
         "auto_size": "Auto size",
         "no_wrap": "Text on one line",
+        "padded_numbers": "Zero-padded timer values",
         "line_spacing": "Line spacing",
         "line_radius": "Line radius",
         "line_height": "Line height",

--- a/src/frontend/components/edit/tools/BoxStyle.svelte
+++ b/src/frontend/components/edit/tools/BoxStyle.svelte
@@ -266,6 +266,8 @@
         setBoxInputValue(box, "default", "font-family", "styleValue", getStyles(style)["font"] || "")
         // setBoxInputValue(box2, "default", "textFit", "hidden", !item?.auto)
         setBoxInputValue(box, "text", "nowrap", "value", !!styles["white-space"]?.includes("nowrap"))
+        setBoxInputValue(box, "text", "dynamicPadding", "value", item?.dynamicPadding !== false)
+        setBoxInputValue(box, "text", "dynamicPadding", "hidden", !item || !getItemText(item).includes("{timer_"))
         setBoxInputValue(box, "lines", "specialStyle.lineRadius", "hidden", !item?.specialStyle?.lineRadius && !item?.specialStyle?.lineBg)
 
         setBoxInputValue(box, "default", "textFit", "value", item?.auto ? "shrinkToFit" : "none") // text items

--- a/src/frontend/components/edit/values/boxes.ts
+++ b/src/frontend/components/edit/values/boxes.ts
@@ -169,7 +169,8 @@ export const textSections: { [key: string]: EditBoxSection } = {
                 // probably not needed as we have line and item background color
                 // { label: "background_color", id: "style", key: "background-color", type: "color", value: "rgb(0 0 0 / 0)", values: { enableNoColor: true } },
                 { id: "nowrap", type: "checkbox", value: false, values: { label: "edit.no_wrap" } }
-            ]
+            ],
+            [{ id: "dynamicPadding", type: "checkbox", value: true, hidden: true, values: { label: "edit.padded_numbers" } }]
         ]
     },
     lines: {

--- a/src/frontend/components/helpers/showActions.ts
+++ b/src/frontend/components/helpers/showActions.ts
@@ -826,7 +826,7 @@ const replaceTokens = (str: string, id: string, inputs: string[] = []) => {
     })
 }
 
-export function replaceDynamicValues(text: string, { showId, layoutId, slideIndex, type, id, mode }: any, _updater = 0, popup = false) {
+export function replaceDynamicValues(text: string, { showId, layoutId, slideIndex, type, id, mode, dynamicPadding }: any, _updater = 0, popup = false) {
     const isOutputWin = isOutputWindow()
 
     if (type === "stage") {
@@ -885,9 +885,11 @@ export function replaceDynamicValues(text: string, { showId, layoutId, slideInde
         if (dynamicId.startsWith("timer_")) {
             let min = dynamicId.startsWith("timer_m_")
             let sec = dynamicId.startsWith("timer_s_")
+            const padded = dynamicPadding !== false
+            const pad = (value: number) => (padded ? value.toString().padStart(2, "0") : value.toString())
             const nameId = dynamicId.slice(min || sec ? 8 : 6)
             const timer = keysToID(get(timers)).find((a) => getVariableNameId(a.name) === nameId)
-            if (!timer) return min || sec ? "00" : "00:00"
+            if (!timer) return min || sec ? pad(0) : `${pad(0)}:00`
 
             const today = new Date()
             const currentTime = Math.floor(getCurrentTimerValue(timer, { id: timer.id }, today))
@@ -896,19 +898,14 @@ export function replaceDynamicValues(text: string, { showId, layoutId, slideInde
             const isOverflowing = getTimerOverflow()
 
             if ((min || sec) && isOverflowing) {
-                if (min || !overflow) return "00"
-                return (currentTime < 0 ? "" : "-") + currentTime.toString().padStart(2, "0")
+                if (min || !overflow) return pad(0)
+                return (currentTime < 0 ? "" : "-") + pad(currentTime)
             }
-            if (min) {
-                return currentTime >= 60
-                    ? Math.floor(currentTime / 60)
-                          .toString()
-                          .padStart(2, "0")
-                    : "00"
-            }
-            if (sec) return (currentTime % 60).toString().padStart(2, "0")
+            if (min) return currentTime >= 60 ? pad(Math.floor(currentTime / 60)) : pad(0)
+            if (sec) return pad(currentTime % 60)
 
-            const timeValue = joinTimeBig(typeof currentTime === "number" ? currentTime : 0)
+            let timeValue = joinTimeBig(typeof currentTime === "number" ? currentTime : 0)
+            if (!padded) timeValue = timeValue.replace(/^(\d+, )?0(?=\d)/, "$1")
             if (isOverflowing) return `-${timeValue}`
             return timeValue
 

--- a/src/frontend/components/slide/TextboxLines.svelte
+++ b/src/frontend/components/slide/TextboxLines.svelte
@@ -246,7 +246,7 @@
     const previousValue: { [key: string]: string } = {}
     function getTextValue(value: string, i: number, ti: number, _updater: number) {
         if (dynamicValues && value.includes("{")) {
-            const newValue = replaceDynamicValues(value, { ...ref, slideIndex })
+            const newValue = replaceDynamicValues(value, { ...ref, slideIndex, dynamicPadding: item?.dynamicPadding !== false })
 
             const id = i + "_" + ti
             if (previousValue[id] !== newValue) {

--- a/src/types/Show.ts
+++ b/src/types/Show.ts
@@ -105,6 +105,7 @@ export interface Item {
     list?: List
     auto?: boolean // DEPRECATED - use textFit
     textFit?: AutosizeTypes // auto size text fix option (default: shrinkToFit)
+    dynamicPadding?: boolean // zero-pad dynamic timer values (default: true)
     autoFontSize?: number // only used to store the calculated auto size text size
     previewAutoFontSize?: number // only used to store the calculated auto size text size for the preview
     style: string


### PR DESCRIPTION
Closes #3515

Adds a per-slide-item checkbox ("Zero-padded timer values") to toggle zero-padding on dynamic timer values, as discussed in the issue.

- The checkbox appears in the text section of the edit panel, only when the item's text contains a `{timer_` dynamic value.
- Default is on, so existing shows are unaffected. Turning it off renders `5:30` instead of `05:30` (also handles single min/sec values, overflow, and timers with hours/days).
- Stored as `dynamicPadding` on the item, following the same pattern as `textFit`.

Tested with `svelte-check` (no new errors in the touched files).