### PR TITLE
Override `tar` version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -534,39 +534,6 @@
                 "node": ">=22.12.0"
             }
         },
-        "node_modules/@electron/rebuild/node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@electron/rebuild/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/@electron/rebuild/node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/@electron/rebuild/node_modules/node-abi": {
             "version": "4.26.0",
             "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-4.26.0.tgz",
@@ -578,33 +545,6 @@
             },
             "engines": {
                 "node": ">=22.12.0"
-            }
-        },
-        "node_modules/@electron/rebuild/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@electron/rebuild/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@electron/universal": {
@@ -2032,7 +1972,6 @@
         },
         "node_modules/@isaacs/fs-minipass": {
             "version": "4.0.1",
-            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "minipass": "^7.0.4"
@@ -2043,7 +1982,6 @@
         },
         "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
             "version": "7.1.2",
-            "dev": true,
             "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
@@ -2171,14 +2109,6 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/chownr": {
-            "version": "3.0.0",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/@mapbox/node-pre-gyp/node_modules/https-proxy-agent": {
             "version": "7.0.6",
             "dev": true,
@@ -2189,29 +2119,6 @@
             },
             "engines": {
                 "node": ">= 14"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
             }
         },
         "node_modules/@mapbox/node-pre-gyp/node_modules/nopt": {
@@ -2226,31 +2133,6 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/@mapbox/node-pre-gyp/node_modules/yallist": {
-            "version": "5.0.0",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/@napi-rs/canvas": {
@@ -4459,16 +4341,6 @@
                 "node": ">=12.0.0"
             }
         },
-        "node_modules/app-builder-lib/node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/app-builder-lib/node_modules/ci-info": {
             "version": "4.3.1",
             "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-4.3.1.tgz",
@@ -4510,29 +4382,6 @@
                 "node": ">=18"
             }
         },
-        "node_modules/app-builder-lib/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/app-builder-lib/node_modules/semver": {
             "version": "7.7.4",
             "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
@@ -4544,23 +4393,6 @@
             },
             "engines": {
                 "node": ">=10"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/app-builder-lib/node_modules/which": {
@@ -4577,16 +4409,6 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/app-builder-lib/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/aproba": {
@@ -5106,16 +4928,6 @@
                 "balanced-match": "^1.0.0"
             }
         },
-        "node_modules/cacache/node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/cacache/node_modules/fs-minipass": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-3.0.3.tgz",
@@ -5182,46 +4994,6 @@
             "license": "ISC",
             "engines": {
                 "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/cacache/node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
-        "node_modules/cacache/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
-        "node_modules/cacache/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/cacheable": {
@@ -5384,10 +5156,12 @@
             }
         },
         "node_modules/chownr": {
-            "version": "2.0.0",
-            "license": "ISC",
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
+            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/chromium-pickle-js": {
@@ -7782,16 +7556,6 @@
                 "node": ">=10"
             }
         },
-        "node_modules/fs-minipass": {
-            "version": "2.1.0",
-            "license": "ISC",
-            "dependencies": {
-                "minipass": "^3.0.0"
-            },
-            "engines": {
-                "node": ">= 8"
-            }
-        },
         "node_modules/fs.realpath": {
             "version": "1.0.0",
             "license": "ISC"
@@ -9629,6 +9393,7 @@
         },
         "node_modules/minipass": {
             "version": "3.3.6",
+            "dev": true,
             "license": "ISC",
             "dependencies": {
                 "yallist": "^4.0.0"
@@ -9688,19 +9453,6 @@
                 "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/minipass-fetch/node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
-            }
-        },
         "node_modules/minipass-flush": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/minipass-flush/-/minipass-flush-1.0.5.tgz",
@@ -9741,14 +9493,24 @@
             }
         },
         "node_modules/minizlib": {
-            "version": "2.1.2",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
+            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
             "license": "MIT",
             "dependencies": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
+                "minipass": "^7.1.2"
             },
             "engines": {
-                "node": ">= 8"
+                "node": ">= 18"
+            }
+        },
+        "node_modules/minizlib/node_modules/minipass": {
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": ">=16 || 14 >=14.17"
             }
         },
         "node_modules/mkdirp": {
@@ -9951,16 +9713,6 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/node-gyp/node_modules/chownr": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz",
-            "integrity": "sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/node-gyp/node_modules/isexe": {
             "version": "3.1.5",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.5.tgz",
@@ -9969,29 +9721,6 @@
             "license": "BlueOak-1.0.0",
             "engines": {
                 "node": ">=18"
-            }
-        },
-        "node_modules/node-gyp/node_modules/minipass": {
-            "version": "7.1.2",
-            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz",
-            "integrity": "sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==",
-            "dev": true,
-            "license": "ISC",
-            "engines": {
-                "node": ">=16 || 14 >=14.17"
-            }
-        },
-        "node_modules/node-gyp/node_modules/minizlib": {
-            "version": "3.1.0",
-            "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz",
-            "integrity": "sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==",
-            "dev": true,
-            "license": "MIT",
-            "dependencies": {
-                "minipass": "^7.1.2"
-            },
-            "engines": {
-                "node": ">= 18"
             }
         },
         "node_modules/node-gyp/node_modules/nopt": {
@@ -10010,23 +9739,6 @@
                 "node": "^18.17.0 || >=20.5.0"
             }
         },
-        "node_modules/node-gyp/node_modules/tar": {
-            "version": "7.5.16",
-            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
-            "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "dependencies": {
-                "@isaacs/fs-minipass": "^4.0.0",
-                "chownr": "^3.0.0",
-                "minipass": "^7.1.2",
-                "minizlib": "^3.1.0",
-                "yallist": "^5.0.0"
-            },
-            "engines": {
-                "node": ">=18"
-            }
-        },
         "node_modules/node-gyp/node_modules/which": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/which/-/which-5.0.0.tgz",
@@ -10041,16 +9753,6 @@
             },
             "engines": {
                 "node": "^18.17.0 || >=20.5.0"
-            }
-        },
-        "node_modules/node-gyp/node_modules/yallist": {
-            "version": "5.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
-            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
-            "dev": true,
-            "license": "BlueOak-1.0.0",
-            "engines": {
-                "node": ">=18"
             }
         },
         "node_modules/node-html-parser": {
@@ -13027,18 +12729,19 @@
             }
         },
         "node_modules/tar": {
-            "version": "6.2.1",
-            "license": "ISC",
+            "version": "7.5.20",
+            "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.20.tgz",
+            "integrity": "sha512-9FcyK4PA6+WbzlTM9WhQm6vB5W7cP7dUiPsv1g7YDwEQnQ1CGpK3MGlKk/ITVWMk05kHZuBhmVhiv8LZoy/PFQ==",
+            "license": "BlueOak-1.0.0",
             "dependencies": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^5.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
+                "@isaacs/fs-minipass": "^4.0.0",
+                "chownr": "^3.0.0",
+                "minipass": "^7.1.2",
+                "minizlib": "^3.1.0",
+                "yallist": "^5.0.0"
             },
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/tar-fs": {
@@ -13076,20 +12779,21 @@
             }
         },
         "node_modules/tar/node_modules/minipass": {
-            "version": "5.0.0",
-            "license": "ISC",
+            "version": "7.1.3",
+            "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+            "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=8"
+                "node": ">=16 || 14 >=14.17"
             }
         },
-        "node_modules/tar/node_modules/mkdirp": {
-            "version": "1.0.4",
-            "license": "MIT",
-            "bin": {
-                "mkdirp": "bin/cmd.js"
-            },
+        "node_modules/tar/node_modules/yallist": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz",
+            "integrity": "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==",
+            "license": "BlueOak-1.0.0",
             "engines": {
-                "node": ">=10"
+                "node": ">=18"
             }
         },
         "node_modules/temp": {
@@ -15062,6 +14766,7 @@
         },
         "node_modules/yallist": {
             "version": "4.0.0",
+            "dev": true,
             "license": "ISC"
         },
         "node_modules/yargs": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     },
     "overrides": {
         "shell-quote": "^1.8.4",
-        "tmp": "^0.2.7"
+        "tmp": "^0.2.7",
+        "tar": "^7.5.20"
     },
     "scripts": {
         "postinstall": "electron-builder install-app-deps",


### PR DESCRIPTION
# Fix critical `tar` vulnerability

## Summary

Resolves the **critical** `tar` (node-tar) advisory reported by `npm audit`. `tar` is a
transitive dependency only — pulled in by build tooling (`@mapbox/node-pre-gyp`,
`@electron/rebuild`, `app-builder-lib`, `cacache`, `node-gyp`) and by
`@discordjs/opus → @discordjs/node-pre-gyp`. This project's own source never imports
`tar` (it uses `yauzl`/`yazl` for archives).

### Changes

- **`package.json`** — added a dependency override to force every transitive copy of
  `tar` onto the patched line:

  ```jsonc
  "overrides": {
      "shell-quote": "^1.8.4",
      "tmp": "^0.2.7",
      "tar": "^7.5.20"   // added
  }
  ```

- **`package-lock.json`** — regenerated. All `tar` copies now resolve to `7.5.20`
  (previously a mix of `7.5.16` and `6.2.1`). The lockfile actually shrank, as the
  override deduped the old tar sub-trees.

### Result

- Critical `tar` advisory: **resolved** — `tar` no longer appears in `npm audit`.
- Total critical vulnerabilities: **2 → 1** (the remaining one, `vitest`, is tracked
  separately and is not part of this PR).

## Breaking changes (why they do NOT impact us)

The bump crosses a major boundary: `tar` `6.2.1 → 7.5.20`. Per the
[node-tar changelog](https://github.com/isaacs/node-tar/blob/main/CHANGELOG.md), the
v7.0.0 breaking changes and why each is a non-issue here:

| Breaking change (v6 → v7) | Impact |
|---|---|
| Drops Node < 18 (now requires Node ≥ 18) | **None** — repo requires `node >= 22.12.0` (`engines`). |
| Rewritten in TypeScript; now an ESM + CommonJS hybrid (`"type": "module"`) | **None** — `require('tar')` still works via the CJS interface; verified `create`/`extract`/`c`/`x` are all exported. |
| `noChmod` option deprecated in favor of new `chmod` option (defaults to `false`) | **None** — no consumer in the tree uses `noChmod`. |
| Added `processUmask` option; tree-shakeable subpath exports (`tar/create`, …) | **None** — additive, not breaking. |

### Consumer audit

The only package that was on `tar@6` is `@discordjs/opus → @discordjs/node-pre-gyp`.
Its tar usage was reviewed directly:

- `lib/install.js` → `tar.extract({ cwd, strip, onentry })`
- `lib/package.js` → `tar.create({ portable, gzip, filter, file, cwd }, files, callback)`

Every method and option used is unchanged and fully supported in tar 7, and none touch
the changed surface (no `noChmod`, no ESM-only import).

### Verification

- `npm install` completes cleanly, including the `postinstall` native-deps step
  (`electron-builder install-app-deps`), which exercises the node-pre-gyp / tar paths.
- `npm ls tar --all` → every entry is `7.5.20`; no `tar@6.x` remaining.
- `npm audit` → no critical `tar` entry.

Suggested additional checks before merge:

- `npm run rebuild-opus` — exercises the `@discordjs/opus` path that previously used tar 6.
- `npm run pack` — electron-builder / `@electron/rebuild` packaging (tar-dependent build paths).
