### PR TITLE
Fix: httpsRequest never aborts on timeout, can hang cloud sync forever

### DIFF
--- a/src/electron/utils/requests.test.ts
+++ b/src/electron/utils/requests.test.ts
@@ -1,0 +1,81 @@
+import { EventEmitter } from "events"
+import { describe, expect, it, vi } from "vitest"
+
+vi.mock("../IPC/responsesMain", () => ({
+    createLog: (err: any) => ({ message: String(err?.message || err) }),
+    logError: () => {}
+}))
+
+vi.mock("./files", () => ({
+    createFolder: () => {}
+}))
+
+// Fake ClientRequest that mimics the two Node.js behaviors this test cares about:
+// - options.timeout alone only emits a "timeout" event, it never aborts the connection on its own.
+// - calling .destroy(err) on a real ClientRequest asynchronously emits an "error" event with err.
+// This lets the test drive httpsRequest() through the exact hang scenario without opening real sockets.
+class FakeClientRequest extends EventEmitter {
+    destroyed = false
+    write() {}
+    end() {}
+    destroy(err?: Error) {
+        this.destroyed = true
+        if (err) queueMicrotask(() => this.emit("error", err))
+    }
+}
+
+class FakeResponse extends EventEmitter {
+    statusCode = 200
+    headers = {}
+    pipe() {}
+}
+
+let lastRequest: FakeClientRequest
+let lastResponse: FakeResponse
+
+vi.mock("https", () => ({
+    default: {
+        request: (_options: any, onResponse: any) => {
+            lastRequest = new FakeClientRequest()
+            lastResponse = new FakeResponse()
+            lastRequest.on("__respond", () => onResponse(lastResponse))
+            return lastRequest
+        }
+    }
+}))
+
+import { httpsRequest } from "./requests"
+
+describe("httpsRequest", () => {
+    it("calls the callback with a timeout error once the timeout event fires, instead of hanging forever", async () => {
+        const cb = vi.fn()
+        httpsRequest("example.com", "/", "GET", {}, {}, cb)
+
+        // simulate Node emitting "timeout" after options.timeout elapses on a hung connection
+        lastRequest.emit("timeout")
+
+        await new Promise((r) => setTimeout(r, 10))
+        expect(cb).toHaveBeenCalledTimes(1)
+        const [err, result] = cb.mock.calls[0]
+        expect(err).toBeInstanceOf(Error)
+        expect(err.message).toMatch(/timed out/i)
+        expect(result).toBeNull()
+        expect(lastRequest.destroyed).toBe(true)
+    })
+
+    it("only calls the callback once when the timeout fires after the response already started (partial response, then hang)", async () => {
+        const cb = vi.fn()
+        httpsRequest("example.com", "/", "GET", {}, {}, cb)
+
+        // response headers arrived, but the body stalls (e.g. a slow/hung backend) - then the
+        // timeout fires; both the request's "error" and the response's own "error" can follow
+        lastRequest.emit("__respond")
+        lastRequest.emit("timeout")
+        await new Promise((r) => setTimeout(r, 0))
+        lastResponse.emit("error", new Error("aborted"))
+
+        await new Promise((r) => setTimeout(r, 10))
+        expect(cb).toHaveBeenCalledTimes(1)
+        expect(cb.mock.calls[0][0].message).toMatch(/timed out/i)
+    })
+})

--- a/src/electron/utils/requests.ts
+++ b/src/electron/utils/requests.ts
@@ -5,7 +5,16 @@ import type { ErrorLog } from "../../types/Main"
 import { createLog, logError } from "../IPC/responsesMain"
 import { createFolder } from "./files"
 
-export function httpsRequest(hostname: string, path: string, method: "POST" | "GET" | "HEAD", headers: object = {}, content: object = {}, cb: (err: (Error & { statusCode?: number; code?: string; headers?: any }) | null, result?: any) => void, outputFilePath?: string, onlyHeaders = false) {
+export function httpsRequest(hostname: string, path: string, method: "POST" | "GET" | "HEAD", headers: object = {}, content: object = {}, callback: (err: (Error & { statusCode?: number; code?: string; headers?: any }) | null, result?: any) => void, outputFilePath?: string, onlyHeaders = false) {
+    // a hung response can fire both the request's own "error" (from the timeout destroy) and the
+    // response stream's "error"/"end" afterwards - guard so callers only ever see the first result
+    let done = false
+    const cb: typeof callback = (err, result) => {
+        if (done) return
+        done = true
+        callback(err, result)
+    }
+
     const headersObj = headers as Record<string, string>
     const isFormEncoded = headersObj["Content-Type"] === "application/x-www-form-urlencoded"
     let dataString = ""
@@ -90,6 +99,13 @@ export function httpsRequest(hostname: string, path: string, method: "POST" | "G
         request.on("error", (err) => {
             console.error("Request error:", err)
             cb(err, null)
+        })
+
+        // options.timeout alone only emits this event, it does not abort the connection - without
+        // destroying the request here, a hung/slow response left the promise (and callers waiting on
+        // it, e.g. cloud sync) unresolved forever.
+        request.on("timeout", () => {
+            request.destroy(new Error(`Request timed out after ${options.timeout}ms`))
         })
 
         if (dataString.length) request.write(dataString)


### PR DESCRIPTION
httpsRequest() sets a timeout option on the request, but never listens for the timeout event. In Node, that option alone only emits the event, it doesn't abort the connection. If nothing calls .destroy(), a hung/slow response leaves the callback (and anything waiting on it, like cloud sync) unresolved forever.

Fixed by destroying the request on timeout. Also added a small idempotency guard, since a timeout that fires after the response has already started can trigger both the request's and the response's error handlers, which would otherwise call the callback twice.

Confirmed the hang is real: reproduced it against a server that never responds (callback never fires without the fix, resolves at ~10s with it), and saw the app itself hang on "Downloading data..." during testing related to #3494.

Added two tests covering both cases.