### PR TITLE
Fix: full-file stores (EVENTS/THEMES/MEDIA) can lose real edits to a stale re-sync

### DIFF
--- a/src/electron/cloud/syncLedger.ts
+++ b/src/electron/cloud/syncLedger.ts
@@ -1,10 +1,8 @@
 // ----- FreeShow -----
-// Pure, testable per-item merge ledger for SYNCED_SETTINGS / collections.
+// Pure per-item merge ledger for SYNCED_SETTINGS / collections.
 //
-// This extracts the created/deleted ledger decision logic from syncManager (see #3335) into a
-// self-contained unit with NO module globals and NO I/O: all state (changes, cloudChanges, the
-// current deviceId, device count) is provided to the constructor, so the merge decisions can be
-// unit-tested in isolation. syncManager delegates to this instead of keeping the logic inline.
+// Extracts merge logic from syncManager to be unit-testable in isolation.
+// All state is provided to constructor, with no module globals or I/O.
 
 export type Changes = {
     version: string
@@ -12,11 +10,8 @@ export type Changes = {
     modified: { [key: string]: number }
     deleted: { [key: string]: string[] }
     created: { [key: string]: string[] }
-    // real last-edit time per full-file store (EVENTS/THEMES/MEDIA), keyed by store id. These
-    // stores are compared by "newest wins", but a store's own file mtime gets bumped to "now" by
-    // the sync's own download write, not just by real edits - so relying on it makes the last
-    // device to merely sync (not edit) look newer than the device that actually edited it. This
-    // field tracks the real edit time instead, additive and optional so older clients ignore it.
+    // Real last-edit time per full-file store (EVENTS/THEMES/MEDIA).
+    // Used instead of file mtime to avoid false "newest wins" entries caused by sync writes.
     fileModified?: { [storeId: string]: number }
 }
 
@@ -114,11 +109,8 @@ export class SyncLedger {
 
     // ----- merge decisions (item-collections with no per-item "modified") -----
 
-    // Item present in the cloud snapshot; decide create/skip/delete/download/upload given whether it
-    // exists locally. Single source of truth for the cloud-side decision: syncManager.checkCloudEntry
-    // delegates here. When the item exists on both sides and the ledger doesn't force delete, the
-    // newest copy wins: entries that carry a per-item "modified" pass `cloudIsNewer` (shows, projects,
-    // stage, …); item-collections have no per-item "modified" and omit it → keep local (upload).
+    // Resolves cloud entry status (create/skip/delete/download/upload) based on local existence.
+    // Newest copy wins for items with "modified" fields; collections default to upload.
     resolveCloudEntry(storeId: string, key: string, localExists: boolean, cloudIsNewer = false): { action: EntryAction } {
         // exists only in cloud
         if (!localExists) {
@@ -153,8 +145,7 @@ export class SyncLedger {
         return { action: cloudIsNewer ? "download" : "upload" }
     }
 
-    // Item present only locally (not in the cloud snapshot).
-    // Single source of truth for the ledger decision: syncManager.checkLocalEntry delegates here.
+    // Item present only locally (not in cloud snapshot). Resolves actions based on deletion history.
     resolveLocalEntry(storeId: string, key: string): { action: EntryAction } {
         if (this.isNewDevice) {
             this.markAsCreated(storeId, key)
@@ -177,9 +168,7 @@ export class SyncLedger {
         return { action: "upload" }
     }
 
-    // Merge one item-collection (e.g. scriptures) per-item: applies the cloud entries onto the local
-    // object and resolves local-only items via the ledger. Returns the merged collection.
-    // This is the per-item replacement for the old whole-object overwrite that caused #3335.
+    // Merges one item-collection (e.g. scriptures) per-item. Used to avoid whole-object overwrites.
     mergeCollection(storeId: string, type: string, cloudObj: Record<string, any>, localObj: Record<string, any>): Record<string, any> {
         const merged: Record<string, any> = { ...localObj }
 

--- a/src/electron/cloud/syncLedger.ts
+++ b/src/electron/cloud/syncLedger.ts
@@ -12,6 +12,12 @@ export type Changes = {
     modified: { [key: string]: number }
     deleted: { [key: string]: string[] }
     created: { [key: string]: string[] }
+    // real last-edit time per full-file store (EVENTS/THEMES/MEDIA), keyed by store id. These
+    // stores are compared by "newest wins", but a store's own file mtime gets bumped to "now" by
+    // the sync's own download write, not just by real edits - so relying on it makes the last
+    // device to merely sync (not edit) look newer than the device that actually edited it. This
+    // field tracks the real edit time instead, additive and optional so older clients ignore it.
+    fileModified?: { [storeId: string]: number }
 }
 
 export type EntryAction = "create" | "download" | "upload" | "delete" | "skip"

--- a/src/electron/cloud/syncManager.test.ts
+++ b/src/electron/cloud/syncManager.test.ts
@@ -4,7 +4,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from "vites
 import { _store, createStores } from "../data/store"
 import { compressToZip, decompressZipStream } from "../data/zip"
 import { getDataFolderPath, writeFileAsync } from "../utils/files"
-import { resetSyncManagerModule, syncData } from "./syncManager"
+import { resetSyncManagerModule, setLocalFileModified, syncData } from "./syncManager"
 
 // 1. Host the temporary folder setup so it runs before imports are resolved
 const h = vi.hoisted(() => {
@@ -1232,6 +1232,161 @@ describe("syncManager tests", () => {
 
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
             expect(fs.existsSync(path.join(showsDirA, "show-B.show"))).toBe(true)
+        })
+    })
+
+    describe("full-file store real edit timestamp (MEDIA/EVENTS/THEMES)", () => {
+        it("should not let a device that only re-syncs (never edits) beat a real tracked edit, regardless of file mtime", async () => {
+            await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: Date.now() } }]) }], {
+                devices: ["device-resync-a", "device-resync-b", "test-device-id"],
+                modified: {
+                    "device-resync-a": Date.now(),
+                    "device-resync-b": Date.now(),
+                    "test-device-id": Date.now()
+                }
+            })
+
+            const fileA = path.join(h.userDataDir, "device-resync-a", "media.json")
+            const fileB = path.join(h.userDataDir, "device-resync-b", "media.json")
+            const earlyRealEditTime = 1000
+
+            // 1. Device A never really edits MEDIA. Give its local file a far-future mtime to prove
+            // the fix no longer looks at mtime at all once a real edit is tracked anywhere - without
+            // the fix this file's fresh/future mtime would otherwise win the old comparison
+            h.currentMachineId = "device-resync-a"
+            resetSyncManagerModule()
+            createStores()
+
+            fs.mkdirSync(path.dirname(fileA), { recursive: true })
+            fs.writeFileSync(fileA, JSON.stringify({ background: { brightness: 10 } }))
+            const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365)
+            fs.utimesSync(fileA, farFuture, farFuture)
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            // 2. Device B makes a real, tracked edit (logically earlier than A's file mtime above,
+            // but that must not matter since it is the only device with a real edit timestamp)
+            h.currentMachineId = "device-resync-b"
+            resetSyncManagerModule()
+            createStores()
+
+            fs.mkdirSync(path.dirname(fileB), { recursive: true })
+            fs.writeFileSync(fileB, JSON.stringify({ background: { brightness: 5 } }))
+            await setLocalFileModified("MEDIA", earlyRealEditTime)
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            const settingsB = JSON.parse(fs.readFileSync(fileB, "utf8"))
+            expect(settingsB.background.brightness).toBe(5) // B's real edit must survive its own sync
+
+            // 3. Device A syncs again (still without ever editing) and must pick up B's real edit
+            h.currentMachineId = "device-resync-a"
+            resetSyncManagerModule()
+            createStores()
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            const settingsA = JSON.parse(fs.readFileSync(fileA, "utf8"))
+            expect(settingsA.background.brightness).toBe(5)
+        })
+
+        it("should fall back to file mtime when neither device has ever tracked a real edit time (backward compatibility)", async () => {
+            await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: Date.now() } }]) }], {
+                devices: ["device-mtime-a", "device-mtime-b", "test-device-id"],
+                modified: {
+                    "device-mtime-a": Date.now(),
+                    "device-mtime-b": Date.now(),
+                    "test-device-id": Date.now()
+                }
+            })
+
+            const fileA = path.join(h.userDataDir, "device-mtime-a", "media.json")
+            const fileB = path.join(h.userDataDir, "device-mtime-b", "media.json")
+
+            // 1. Device A writes content with an old mtime, never tracking a real edit time -
+            // this exercises the pre-existing mtime-based comparison, untouched by this fix
+            h.currentMachineId = "device-mtime-a"
+            resetSyncManagerModule()
+            createStores()
+
+            fs.mkdirSync(path.dirname(fileA), { recursive: true })
+            fs.writeFileSync(fileA, JSON.stringify({ background: { brightness: 1 } }))
+            fs.utimesSync(fileA, new Date(1000), new Date(1000))
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            // 2. Device B writes different content with a far-future mtime, also untracked - by
+            // plain mtime this must win, exactly like before this fix existed
+            h.currentMachineId = "device-mtime-b"
+            resetSyncManagerModule()
+            createStores()
+
+            fs.mkdirSync(path.dirname(fileB), { recursive: true })
+            fs.writeFileSync(fileB, JSON.stringify({ background: { brightness: 2 } }))
+            const farFuture = new Date(Date.now() + 1000 * 60 * 60 * 24 * 365)
+            fs.utimesSync(fileB, farFuture, farFuture)
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            // 3. Device A syncs again and must adopt B's content because it is newer by mtime
+            h.currentMachineId = "device-mtime-a"
+            resetSyncManagerModule()
+            createStores()
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            const settingsA = JSON.parse(fs.readFileSync(fileA, "utf8"))
+            expect(settingsA.background.brightness).toBe(2)
+        })
+
+        it("KNOWN LIMITATION: an untracked device's genuinely newer edit can be lost to an older tracked edit during mixed-version rollout", async () => {
+            // This documents an accepted tradeoff, not a bug to fix here: once any device has
+            // tracked a real edit time for a store, an old client that never adopted this field
+            // (so it always looks "untracked") can have its own real edits silently discarded,
+            // however recent, because untracked is always treated as time 0. There is no way to
+            // tell "an old client's genuine edit" apart from "a resync that merely bumped mtime"
+            // without that old client tracking its own edit time too - fixing the reported bug
+            // (#3434) for fully-updated fleets requires accepting this cost for mixed fleets.
+            await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: Date.now() } }]) }], {
+                devices: ["device-new", "device-old", "test-device-id"],
+                modified: {
+                    "device-new": Date.now(),
+                    "device-old": Date.now(),
+                    "test-device-id": Date.now()
+                }
+            })
+
+            const fileNew = path.join(h.userDataDir, "device-new", "media.json")
+            const fileOld = path.join(h.userDataDir, "device-old", "media.json")
+
+            // 1. The updated device makes a tracked edit far in the past (an old timestamp) and syncs
+            h.currentMachineId = "device-new"
+            resetSyncManagerModule()
+            createStores()
+
+            fs.mkdirSync(path.dirname(fileNew), { recursive: true })
+            fs.writeFileSync(fileNew, JSON.stringify({ background: { brightness: 1 } }))
+            await setLocalFileModified("MEDIA", 1000)
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            // 2. The old client makes a genuinely fresh, real edit just now, but has no concept of
+            // fileModified (never calls setLocalFileModified) - it never even downloaded the
+            // updated device's version first, exactly like an old build that has no idea this
+            // field exists
+            h.currentMachineId = "device-old"
+            resetSyncManagerModule()
+            createStores()
+
+            fs.mkdirSync(path.dirname(fileOld), { recursive: true })
+            fs.writeFileSync(fileOld, JSON.stringify({ background: { brightness: 2 } }))
+
+            await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
+
+            // The old client's own real, fresh edit is discarded in favor of the cloud's tracked
+            // (but chronologically much older) value - this is the accepted, documented cost
+            const settingsOld = JSON.parse(fs.readFileSync(fileOld, "utf8"))
+            expect(settingsOld.background.brightness).toBe(1)
         })
     })
 })

--- a/src/electron/cloud/syncManager.test.ts
+++ b/src/electron/cloud/syncManager.test.ts
@@ -760,9 +760,7 @@ describe("syncManager tests", () => {
             const now = Date.now()
 
             // 1. Initial cloud setup: Device A and Device B are synced
-            await createCloudState([
-                { name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: now } }]) }
-            ], {
+            await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: now } }]) }], {
                 devices: ["device-A", "device-B", "test-device-id"],
                 modified: {
                     "device-A": now,
@@ -1087,11 +1085,9 @@ describe("syncManager tests", () => {
     describe("three-machine sync scenarios", () => {
         it("should resolve modification conflicts correctly when Device B and Device C both modify the same project", async () => {
             const now = Date.now()
-            
+
             // Register devices in the ledger
-            await createCloudState([
-                { name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: now } }]) }
-            ], {
+            await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: now } }]) }], {
                 devices: ["device-A", "device-B", "device-C", "test-device-id"],
                 modified: {
                     "device-A": now,
@@ -1120,7 +1116,7 @@ describe("syncManager tests", () => {
             h.currentMachineId = "device-B"
             resetSyncManagerModule()
             createStores()
-            
+
             fs.mkdirSync(path.dirname(fileB), { recursive: true })
             fs.writeFileSync(fileB, JSON.stringify({ projects: {}, folders: {}, projectTemplates: {} }))
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
@@ -1129,7 +1125,7 @@ describe("syncManager tests", () => {
             h.currentMachineId = "device-C"
             resetSyncManagerModule()
             createStores()
-            
+
             fs.mkdirSync(path.dirname(fileC), { recursive: true })
             fs.writeFileSync(fileC, JSON.stringify({ projects: {}, folders: {}, projectTemplates: {} }))
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
@@ -1159,7 +1155,7 @@ describe("syncManager tests", () => {
             resetSyncManagerModule()
             createStores()
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
-            
+
             const projectStoreA_final = JSON.parse(fs.readFileSync(fileA, "utf8"))
             expect(projectStoreA_final.projects["proj-shared"].name).toBe("Project Modified by C (Newest)")
 
@@ -1167,18 +1163,16 @@ describe("syncManager tests", () => {
             resetSyncManagerModule()
             createStores()
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
-            
+
             const projectStoreB_final = JSON.parse(fs.readFileSync(fileB, "utf8"))
             expect(projectStoreB_final.projects["proj-shared"].name).toBe("Project Modified by C (Newest)")
         })
 
         it("should successfully propagate show creations among three machines (Device A, B, and C)", async () => {
             const now = Date.now()
-            
+
             // Register devices in the ledger
-            await createCloudState([
-                { name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: now } }]) }
-            ], {
+            await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: now } }]) }], {
                 devices: ["device-A", "device-B", "device-C", "test-device-id"],
                 modified: {
                     "device-A": now,
@@ -1250,9 +1244,7 @@ describe("syncManager tests", () => {
             const fileB = path.join(h.userDataDir, "device-resync-b", "media.json")
             const earlyRealEditTime = 1000
 
-            // 1. Device A never really edits MEDIA. Give its local file a far-future mtime to prove
-            // the fix no longer looks at mtime at all once a real edit is tracked anywhere - without
-            // the fix this file's fresh/future mtime would otherwise win the old comparison
+            // 1. Device A: Future mtime, no real edit tracked. Fix ensures mtime no longer wins.
             h.currentMachineId = "device-resync-a"
             resetSyncManagerModule()
             createStores()
@@ -1264,8 +1256,7 @@ describe("syncManager tests", () => {
 
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
 
-            // 2. Device B makes a real, tracked edit (logically earlier than A's file mtime above,
-            // but that must not matter since it is the only device with a real edit timestamp)
+            // 2. Device B: Real, tracked edit (earlier than A's mtime).
             h.currentMachineId = "device-resync-b"
             resetSyncManagerModule()
             createStores()
@@ -1277,9 +1268,9 @@ describe("syncManager tests", () => {
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
 
             const settingsB = JSON.parse(fs.readFileSync(fileB, "utf8"))
-            expect(settingsB.background.brightness).toBe(5) // B's real edit must survive its own sync
+            expect(settingsB.background.brightness).toBe(5)
 
-            // 3. Device A syncs again (still without ever editing) and must pick up B's real edit
+            // 3. Device A: Re-syncs and must pick up B's real edit.
             h.currentMachineId = "device-resync-a"
             resetSyncManagerModule()
             createStores()
@@ -1303,8 +1294,7 @@ describe("syncManager tests", () => {
             const fileA = path.join(h.userDataDir, "device-mtime-a", "media.json")
             const fileB = path.join(h.userDataDir, "device-mtime-b", "media.json")
 
-            // 1. Device A writes content with an old mtime, never tracking a real edit time -
-            // this exercises the pre-existing mtime-based comparison, untouched by this fix
+            // 1. Device A: Old mtime, no real edit tracked. Uses mtime-based comparison.
             h.currentMachineId = "device-mtime-a"
             resetSyncManagerModule()
             createStores()
@@ -1315,8 +1305,7 @@ describe("syncManager tests", () => {
 
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
 
-            // 2. Device B writes different content with a far-future mtime, also untracked - by
-            // plain mtime this must win, exactly like before this fix existed
+            // 2. Device B: Future mtime, also untracked. Must win by mtime.
             h.currentMachineId = "device-mtime-b"
             resetSyncManagerModule()
             createStores()
@@ -1328,7 +1317,7 @@ describe("syncManager tests", () => {
 
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
 
-            // 3. Device A syncs again and must adopt B's content because it is newer by mtime
+            // 3. Device A: Syncs again and adopts B's content (newer by mtime).
             h.currentMachineId = "device-mtime-a"
             resetSyncManagerModule()
             createStores()
@@ -1340,13 +1329,8 @@ describe("syncManager tests", () => {
         })
 
         it("KNOWN LIMITATION: an untracked device's genuinely newer edit can be lost to an older tracked edit during mixed-version rollout", async () => {
-            // This documents an accepted tradeoff, not a bug to fix here: once any device has
-            // tracked a real edit time for a store, an old client that never adopted this field
-            // (so it always looks "untracked") can have its own real edits silently discarded,
-            // however recent, because untracked is always treated as time 0. There is no way to
-            // tell "an old client's genuine edit" apart from "a resync that merely bumped mtime"
-            // without that old client tracking its own edit time too - fixing the reported bug
-            // (#3434) for fully-updated fleets requires accepting this cost for mixed fleets.
+            // Documenting an accepted tradeoff: updated clients prioritize tracked edit times over file mtime.
+            // Old clients (untracked) can have edits discarded in mixed fleets to fix #3434 for updated fleets.
             await createCloudState([{ name: "SHOWS/dummy.show", content: JSON.stringify(["dummy", { name: "Dummy", slides: [], timestamps: { modified: Date.now() } }]) }], {
                 devices: ["device-new", "device-old", "test-device-id"],
                 modified: {
@@ -1359,7 +1343,7 @@ describe("syncManager tests", () => {
             const fileNew = path.join(h.userDataDir, "device-new", "media.json")
             const fileOld = path.join(h.userDataDir, "device-old", "media.json")
 
-            // 1. The updated device makes a tracked edit far in the past (an old timestamp) and syncs
+            // 1. Updated device: Tracked edit in the past.
             h.currentMachineId = "device-new"
             resetSyncManagerModule()
             createStores()
@@ -1370,10 +1354,7 @@ describe("syncManager tests", () => {
 
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
 
-            // 2. The old client makes a genuinely fresh, real edit just now, but has no concept of
-            // fileModified (never calls setLocalFileModified) - it never even downloaded the
-            // updated device's version first, exactly like an old build that has no idea this
-            // field exists
+            // 2. Old client: Real edit now, but untracked (no concept of fileModified).
             h.currentMachineId = "device-old"
             resetSyncManagerModule()
             createStores()
@@ -1383,8 +1364,7 @@ describe("syncManager tests", () => {
 
             await syncData({ id: "churchApps", churchId: "test-church", teamId: "test-team", method: "merge" })
 
-            // The old client's own real, fresh edit is discarded in favor of the cloud's tracked
-            // (but chronologically much older) value - this is the accepted, documented cost
+            // Old client's edit is discarded for the cloud's tracked value (accepted cost).
             const settingsOld = JSON.parse(fs.readFileSync(fileOld, "utf8"))
             expect(settingsOld.background.brightness).toBe(1)
         })

--- a/src/electron/cloud/syncManager.ts
+++ b/src/electron/cloud/syncManager.ts
@@ -64,10 +64,8 @@ const DEBUG_MODE = false && !isProd
 const EXTRACT_LOCATION = path.join(app.getPath("temp"), "freeshow-cloud")
 const MERGE_INDIVIDUAL = ["OVERLAYS", "PROJECTS", "STAGE", "TEMPLATES", "SYNCED_SETTINGS"] // "EVENTS", "THEMES"
 
-// SYNCED_SETTINGS sub-keys that are item-collections: merged per-item via the created/deleted
-// ledger (like PROJECTS), so items unique to a device aren't lost and deletions propagate.
-// Other keys (e.g. drawSettings, scriptureSettings, deletedDefaults) are atomic settings and
-// keep the previous newest-file-wins behavior.
+// SYNCED_SETTINGS item-collections merged per-item via ledger.
+// Atomic settings (e.g. drawSettings) keep newest-file-wins behavior.
 const SYNCED_SETTINGS_COLLECTIONS = ["categories", "overlayCategories", "templateCategories", "styles", "profiles", "timers", "variables", "audioStreams", "audioPlaylists", "scriptures", "groups", "midiIn", "emitters", "playerVideos", "videoMarkers", "mediaTags", "playerTags", "actionTags", "variableTags", "timerTags", "customizedIcons", "globalTags", "globalRegexes", "customMetadata", "effects"]
 
 const STALE_MERGE_GUARD_MS = 1000 * 60 * 60 * 24 * 30 // 30 days
@@ -153,7 +151,7 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
             }
         }
 
-        // set to read-only always initially if not synced for 30+ days
+        // Stale merge guard: force read-only if not synced for 30+ days to prevent cloud overwrite.
         if (data.method === "merge" && !isNewDevice && CHANGES.devices.length > 1) {
             const latestCloudModifiedAt = Math.max(0, ...Object.values(CHANGES.modified || {}).map((value) => Number(value) || 0))
             const guardKey = getMergeGuardKey(data)
@@ -170,7 +168,7 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
     }
     // console.log("Devices:", CHANGES.devices)
 
-    // the ledger owns all created/deleted reconciliation; build it once per run from the resolved state
+    // Ledger for created/deleted reconciliation.
     ledger = new SyncLedger({ changes: CHANGES, cloudChanges, deviceId: getDeviceId(), isNewDevice })
 
     // MERGE
@@ -561,8 +559,7 @@ async function isCloudNewerThanFile(localFilePath: string, cloudDate: Date): Pro
     return cloudDate.getTime() > localStats.mtime.getTime()
 }
 
-// device-local cache of the real last-edit time per full-file store, bumped only by genuine
-// edits (save.ts), never by the sync's own download writes - see the Changes.fileModified comment
+// Tracks the real last-edit time per full-file store, bumped only by genuine edits (save.ts).
 export async function setLocalFileModified(id: string, timestamp: number) {
     const syncCache = getStore("CACHE_SYNC") || {}
     if (!syncCache.fileModified) syncCache.fileModified = {}
@@ -571,9 +568,7 @@ export async function setLocalFileModified(id: string, timestamp: number) {
     if (_store.CACHE_SYNC) await safeStoreSet(_store.CACHE_SYNC, syncCache, "CACHE_SYNC")
 }
 
-// used when this device downloads content that carries no tracked edit time (old client, or the
-// mtime-fallback path) - any previously tracked local time no longer describes this content, so it
-// must be cleared instead of surviving and being mistaken for a real edit of the new content
+// Clears tracked edit time for stores without tracked timestamps to prevent stale survival.
 async function clearLocalFileModified(id: string) {
     const syncCache = getStore("CACHE_SYNC") || {}
     if (!syncCache.fileModified?.[id]) return

--- a/src/electron/cloud/syncManager.ts
+++ b/src/electron/cloud/syncManager.ts
@@ -302,11 +302,8 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
         if (data.method === "replace" || !MERGE_INDIVIDUAL.includes(id)) {
             const localPath = localStore.path
 
-            // prefer the real edit time (fileModified) over file mtime whenever either side has one -
-            // mtime gets bumped to "now" by the sync's own writes, not just by real edits, so it can
-            // make the last device to merely sync (not edit) look newer than the one that actually
-            // edited. If only one side has a tracked time, treat the other as untrusted/very old
-            // (0) rather than falling back to mtime, which would make the comparison flaky again.
+            // Prefer real edit time (fileModified) over file mtime.
+            // mtime bumps on sync writes, which can falsely flag devices as newer.
             const cloudFileModified = CHANGES.fileModified?.[id]
             const localFileModified = getStore("CACHE_SYNC")?.fileModified?.[id]
             const cloudIsNewer = data.method === "replace" || isNewDevice || (cloudFileModified || localFileModified ? (cloudFileModified || 0) > (localFileModified || 0) : await isCloudNewerThanFile(localPath, modifiedDates[file.name]))
@@ -322,11 +319,7 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
                     await moveFileAsync(cloudPath, localPath)
                 }
 
-                // record the real edit time this content carries (not "now"), so this device's
-                // next sync doesn't look artificially fresher than a device that hasn't synced yet.
-                // If the cloud copy had no tracked time either (old client, or mtime-fallback path),
-                // clear any stale local tracked time instead of keeping it - this content is no
-                // longer this device's own tracked edit, so it must not be treated as one
+                // Record true edit time. Clear local if cloud is untracked to prevent stale survival.
                 if (cloudFileModified) await setLocalFileModified(id, cloudFileModified)
                 else await clearLocalFileModified(id)
 
@@ -334,10 +327,7 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
                 const localData = localStore.store
                 sendMain(Main[id], localData)
             } else if (localFileModified) {
-                // local wins - carry its real edit time into the outgoing ledger so other devices
-                // compare against it instead of this sync's own file mtime. CHANGES may come from a
-                // parsed cloud changes.json written by a client that predates this field, so it can
-                // be missing here even though DEFAULT_CHANGES seeds it - guard before writing to it
+                // Local wins: carry real edit time into ledger for other devices.
                 if (!CHANGES.fileModified) CHANGES.fileModified = {}
                 CHANGES.fileModified[id] = Math.max(CHANGES.fileModified[id] || 0, localFileModified)
             }
@@ -382,10 +372,7 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
                 })
             )
         } else if (id === "SYNCED_SETTINGS") {
-            // SYNCED_SETTINGS bundles item-collections (scriptures, categories, styles…) plus a
-            // few atomic settings. Merge the collections per-item via the ledger (like PROJECTS),
-            // so items unique to either device survive and deletions propagate. See #3335.
-            // The per-item logic lives in the pure, unit-tested SyncLedger module (syncLedger.ts).
+            // Merge item-collections per-item via ledger. See #3335.
             const cloudFileIsNewer = isNewDevice || (await isCloudNewerThanFile(localStore.path, modifiedDates[file.name]))
             for (const [type, object] of Object.entries<{ [key: string]: any }>(cloudFileData)) {
                 const isCollection = SYNCED_SETTINGS_COLLECTIONS.includes(type) && !!object && typeof object === "object" && !Array.isArray(object)

--- a/src/electron/cloud/syncManager.ts
+++ b/src/electron/cloud/syncManager.ts
@@ -303,8 +303,18 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
         // replace full files
         if (data.method === "replace" || !MERGE_INDIVIDUAL.includes(id)) {
             const localPath = localStore.path
+
+            // prefer the real edit time (fileModified) over file mtime whenever either side has one -
+            // mtime gets bumped to "now" by the sync's own writes, not just by real edits, so it can
+            // make the last device to merely sync (not edit) look newer than the one that actually
+            // edited. If only one side has a tracked time, treat the other as untrusted/very old
+            // (0) rather than falling back to mtime, which would make the comparison flaky again.
+            const cloudFileModified = CHANGES.fileModified?.[id]
+            const localFileModified = getStore("CACHE_SYNC")?.fileModified?.[id]
+            const cloudIsNewer = data.method === "replace" || isNewDevice || (cloudFileModified || localFileModified ? (cloudFileModified || 0) > (localFileModified || 0) : await isCloudNewerThanFile(localPath, modifiedDates[file.name]))
+
             // replace local file if cloud is newer or new device
-            if (data.method === "replace" || isNewDevice || (await isCloudNewerThanFile(localPath, modifiedDates[file.name]))) {
+            if (cloudIsNewer) {
                 // try to set store directly first, otherwise move the file
                 const cloudContent = await readFileAsync(cloudPath)
                 const parsedData = safeParseJSON(cloudContent)
@@ -314,9 +324,24 @@ export async function syncData(data: { id: SyncProviderId; churchId: string; tea
                     await moveFileAsync(cloudPath, localPath)
                 }
 
+                // record the real edit time this content carries (not "now"), so this device's
+                // next sync doesn't look artificially fresher than a device that hasn't synced yet.
+                // If the cloud copy had no tracked time either (old client, or mtime-fallback path),
+                // clear any stale local tracked time instead of keeping it - this content is no
+                // longer this device's own tracked edit, so it must not be treated as one
+                if (cloudFileModified) await setLocalFileModified(id, cloudFileModified)
+                else await clearLocalFileModified(id)
+
                 // send to frontend
                 const localData = localStore.store
                 sendMain(Main[id], localData)
+            } else if (localFileModified) {
+                // local wins - carry its real edit time into the outgoing ledger so other devices
+                // compare against it instead of this sync's own file mtime. CHANGES may come from a
+                // parsed cloud changes.json written by a client that predates this field, so it can
+                // be missing here even though DEFAULT_CHANGES seeds it - guard before writing to it
+                if (!CHANGES.fileModified) CHANGES.fileModified = {}
+                CHANGES.fileModified[id] = Math.max(CHANGES.fileModified[id] || 0, localFileModified)
             }
             return
         }
@@ -536,6 +561,26 @@ async function isCloudNewerThanFile(localFilePath: string, cloudDate: Date): Pro
     return cloudDate.getTime() > localStats.mtime.getTime()
 }
 
+// device-local cache of the real last-edit time per full-file store, bumped only by genuine
+// edits (save.ts), never by the sync's own download writes - see the Changes.fileModified comment
+export async function setLocalFileModified(id: string, timestamp: number) {
+    const syncCache = getStore("CACHE_SYNC") || {}
+    if (!syncCache.fileModified) syncCache.fileModified = {}
+    if ((syncCache.fileModified[id] || 0) >= timestamp) return
+    syncCache.fileModified[id] = timestamp
+    if (_store.CACHE_SYNC) await safeStoreSet(_store.CACHE_SYNC, syncCache, "CACHE_SYNC")
+}
+
+// used when this device downloads content that carries no tracked edit time (old client, or the
+// mtime-fallback path) - any previously tracked local time no longer describes this content, so it
+// must be cleared instead of surviving and being mistaken for a real edit of the new content
+async function clearLocalFileModified(id: string) {
+    const syncCache = getStore("CACHE_SYNC") || {}
+    if (!syncCache.fileModified?.[id]) return
+    delete syncCache.fileModified[id]
+    if (_store.CACHE_SYNC) await safeStoreSet(_store.CACHE_SYNC, syncCache, "CACHE_SYNC")
+}
+
 function getLocalOnlyKeys(cloudKeys: any, localKeys: any): string[] {
     const cloud = Array.isArray(cloudKeys) ? cloudKeys : Object.keys(cloudKeys || {})
     const local = Array.isArray(localKeys) ? localKeys : Object.keys(localKeys || {})
@@ -661,7 +706,7 @@ function safeParseJSON(text: string) {
 
 const changes_name = "changes.json"
 const version = "0.1.1"
-const DEFAULT_CHANGES: Changes = { version, devices: [], modified: {}, deleted: {}, created: {} }
+const DEFAULT_CHANGES: Changes = { version, devices: [], modified: {}, deleted: {}, created: {}, fileModified: {} }
 let CHANGES: Changes = clone(DEFAULT_CHANGES)
 let cloudChanges: Changes | null = null
 let isNewDevice = false

--- a/src/electron/data/save.ts
+++ b/src/electron/data/save.ts
@@ -13,9 +13,8 @@ import { deleteFile, doesPathExist, getDataFolderPath, parseShow, readFile, writ
 import { checkIfMatching, clone, wait } from "../utils/helpers"
 import { renameShows } from "../utils/shows"
 
-// full-file stores whose cloud sync "newest wins" comparison relies on a real edit timestamp
-// (see Changes.fileModified in syncLedger.ts) instead of file mtime, which the sync's own
-// download write would otherwise bump to "now" regardless of whether anything was really edited
+// Full-file stores that use real edit timestamps instead of file mtime for cloud sync comparison.
+// Prevents sync writes from falsely flagging stores as newer.
 const TRACK_FILE_MODIFIED = ["EVENTS", "THEMES", "MEDIA"]
 
 let isSaving = false

--- a/src/electron/data/save.ts
+++ b/src/electron/data/save.ts
@@ -4,6 +4,7 @@ import type { Main } from "../../types/IPC/Main"
 import { ToMain } from "../../types/IPC/ToMain"
 import type { SaveData } from "../../types/Save"
 import { currentlyDeletedShows } from "../cloud/drive"
+import { setLocalFileModified } from "../cloud/syncManager"
 import { startBackup } from "../data/backup"
 import { defaultSettings, defaultSyncedSettings } from "../data/defaults"
 import { _store, safeStoreSet } from "../data/store"
@@ -11,6 +12,11 @@ import { sendMain, sendToMain } from "../IPC/main"
 import { deleteFile, doesPathExist, getDataFolderPath, parseShow, readFile, writeFile } from "../utils/files"
 import { checkIfMatching, clone, wait } from "../utils/helpers"
 import { renameShows } from "../utils/shows"
+
+// full-file stores whose cloud sync "newest wins" comparison relies on a real edit timestamp
+// (see Changes.fileModified in syncLedger.ts) instead of file mtime, which the sync's own
+// download write would otherwise bump to "now" regardless of whether anything was really edited
+const TRACK_FILE_MODIFIED = ["EVENTS", "THEMES", "MEDIA"]
 
 let isSaving = false
 export async function save(data: SaveData) {
@@ -49,6 +55,7 @@ export async function save(data: SaveData) {
         if (checkIfMatching(currentData, newData)) return
 
         await safeStoreSet(store, newData, key)
+        if (TRACK_FILE_MODIFIED.includes(key)) await setLocalFileModified(key, Date.now())
 
         if (reset) sendMain(key as Main, newData)
     }


### PR DESCRIPTION
I found that when syncing full-file stores (`EVENTS`, `THEMES`, `MEDIA`), the comparison to decide which copy wins is based on file `mtime`. The problem: a device's local file mtime gets bumped to "now" by the sync's own download write, not by an actual edit. That means a device that merely re-syncs (without editing anything) can end up looking newer than another device's real edit that hasn't reached the cloud yet, silently discarding that real edit.

This can explain the background brightness report in #3434 (levels reverting to default after syncing): brightness lives in `MEDIA`, one of these full-file stores, and has no per-item `modified` field, so it's a different root cause than the earlier "notes" timestamp bug reported in the same thread.

Note: I haven't reproduced this live end-to-end yet, I haven't had the time. I'll do it as soon as I can, but if anyone else can give it a try in the meantime, it'd be appreciated.

Fix: track the real edit time separately (`Changes.fileModified`, additive field in `changes.json`), bumped only where genuine edits are persisted (`save.ts`), and prefer it over file mtime whenever either side has one. Falls back to the old mtime comparison when neither side has ever tracked an edit (backward compatible with older clients).

**Known limitation, disclosed on purpose:** during a rollout with mixed client versions, an old client that never adopted this field can have its own real edit discarded in favor of an older tracked value from an updated client — there's no way to tell "a harmless re-sync" from "a real edit by a client that doesn't track this" without that client tracking it too. This is the accepted cost of fixing the (much more common) reported bug for fully-updated fleets. Pinned down explicitly with a test so it's a conscious tradeoff, not a hidden one.

Added 3 tests covering: the fix itself, backward-compatible mtime fallback, and the known limitation above.