### PR TITLE
Fixed new empty lines not visible until typing in an empty textbox

### DIFF
--- a/src/frontend/components/edit/editbox/EditboxLines.svelte
+++ b/src/frontend/components/edit/editbox/EditboxLines.svelte
@@ -733,7 +733,7 @@
                 on:cut={handleCut}
                 bind:innerHTML={html}
                 style="{plain || !item.auto ? '' : `--auto-size: ${autoSize}px;`}{!plain ? lineStyleBox : ''}{plain ? '' : typeof item.align === 'string' ? item.align.replace('align-items', 'justify-content') : ''}"
-                class:height={item.lines?.length < 2 && !item.lines?.[0]?.text[0]?.value.length}
+                class:height={!getItemText(item).length}
                 class:tallLines={chordsMode}
             />
             <!-- this did not work on mac: -->


### PR DESCRIPTION
Follow-up to the feedback on #3582.

**Pressing Enter in an empty textbox added the lines to the item, but they were not visible until typing.**

Cause: the `height` class on the editbox — which is what gives empty lines their 1em row height (`.edit.height .break { height: 1em }`) — was keyed to `item.lines?.length < 2`, so the moment Enter created a second empty line the class dropped and the empty lines rendered with no height. Keyed it to "the item has no text" instead (`!getItemText(item).length`), so an all-empty box renders every line the same way the single-empty-line state always has, and it switches back to normal rendering on the first typed character.

On the item-style paste order revert: thanks for catching and reverting that — I couldn't reproduce the order reversal from reading the code (the clipboard from EditTools is built in ascending item order and the `items().set()` path pairs positionally without reordering), so I've left it exactly as you restored it. If you can share quick repro steps I'm happy to dig into the pairing properly.
