### PR TITLE
Align media tab bottom borders

### DIFF
--- a/src/frontend/components/drawer/media/Media.svelte
+++ b/src/frontend/components/drawer/media/Media.svelte
@@ -712,7 +712,7 @@
         display: flex;
         position: relative;
         background-color: var(--primary-darkest);
-        align-items: center;
+        align-items: stretch;
     }
 
     .tabs :global(button) {


### PR DESCRIPTION
Small fix but should fix that uneven border: 
<img width="230" height="27" alt="image" src="https://github.com/user-attachments/assets/40c50de2-eefa-4cd1-8684-d248cc1ac2b7" />
